### PR TITLE
StationPlaylist add-on 20.02

### DIFF
--- a/addon/appModules/splcreator.py
+++ b/addon/appModules/splcreator.py
@@ -8,6 +8,7 @@ import appModuleHandler
 import addonHandler
 import globalVars
 import ui
+import api
 from NVDAObjects.IAccessible import IAccessible, sysListView32
 from .splstudio import splconfig, SPLTrackItem
 addonHandler.initTranslation()
@@ -116,3 +117,40 @@ class AppModule(appModuleHandler.AppModule):
 		elif obj.windowClassName in ("TDemoRegForm", "TAboutForm"):
 			from NVDAObjects.behaviors import Dialog
 			clsList.insert(0, Dialog)
+
+	# The following scripts are designed to work while using Playlist Editor.
+
+	def isPlaylistEditor(self):
+		if api.getForegroundObject().windowClassName != "TEditMain":
+			ui.message("You are not in playlist editor")
+			return False
+		return True
+
+	def script_playlistDateTime(self, gesture):
+		if self.isPlaylistEditor():
+			playlistDateTime = api.getForegroundObject().simpleLastChild.firstChild.next
+			playlistHour = playlistDateTime.simpleNext
+			playlistDay = playlistHour.simpleNext.simpleNext
+			ui.message(" ".join([playlistDay.value, playlistHour.value]))
+
+	def script_playlistDuration(self, gesture):
+		if self.isPlaylistEditor():
+			playlistDuration = api.getForegroundObject().simpleLastChild.firstChild
+			ui.message(playlistDuration.name)
+
+	def script_playlistScheduled(self, gesture):
+		if self.isPlaylistEditor():
+			statusBar = api.getForegroundObject().firstChild.firstChild
+			ui.message(statusBar.getChild(2).name)
+
+	def script_playlistRotation(self, gesture):
+		if self.isPlaylistEditor():
+			statusBar = api.getForegroundObject().firstChild.firstChild
+			ui.message(statusBar.getChild(3).name)
+
+	__gestures = {
+		"kb:alt+NVDA+1": "playlistDateTime",
+		"kb:alt+NVDA+2": "playlistDuration",
+		"kb:alt+NVDA+3": "playlistScheduled",
+		"kb:alt+NVDA+4": "playlistRotation",
+	}

--- a/addon/appModules/splcreator.py
+++ b/addon/appModules/splcreator.py
@@ -59,6 +59,32 @@ class SPLCreatorItem(SPLTrackItem):
 	}
 
 
+class SPLPlaylistEditorItem(SPLTrackItem):
+	"""An entry in SPL Creator's Playlist Editor.
+	"""
+
+	# Keep a record of which column is being looked at.
+	_curColumnNumber = 0
+
+	def indexOf(self, header):
+		try:
+			return self.exploreColumns.index(header)
+		except ValueError:
+			return None
+
+	@property
+	def exploreColumns(self):
+		columns = ['Artist', 'Title', 'Duration', 'Intro', 'Outro', 'Category', 'Filename']
+		if self.appModule.productVersion >= "5.40":
+			columns.append('Rating')
+		return columns
+
+	__gestures={
+		"kb:control+alt+downArrow": None,
+		"kb:control+alt+upArrow": None,
+	}
+
+
 class AppModule(appModuleHandler.AppModule):
 
 	def __init__(self, *args, **kwargs):

--- a/addon/appModules/splcreator.py
+++ b/addon/appModules/splcreator.py
@@ -84,7 +84,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Resort to window style and other tricks if other lists with the class name below is found and are not tracks list.
 		if obj.windowClassName == "TTntListView.UnicodeClass":
 			if obj.role == controlTypes.ROLE_LISTITEM:
-				clsList.insert(0, SPLCreatorItem)
+				clsList.insert(0, SPLCreatorItem if obj.windowStyle == 1443958857 else SPLPlaylistEditorItem)
 			elif obj.role == controlTypes.ROLE_LIST:
 				clsList.insert(0, sysListView32.List)
 		elif obj.windowClassName in ("TDemoRegForm", "TAboutForm"):

--- a/addon/appModules/splengine/encoders.py
+++ b/addon/appModules/splengine/encoders.py
@@ -65,7 +65,7 @@ def loadStreamLabels():
 		SPLPlayAfterConnecting = set(streamLabels["PlayAfterConnecting"])
 	if "BackgroundMonitor" in streamLabels:
 		SPLBackgroundMonitor = set(streamLabels["BackgroundMonitor"])
-	if "ConnectionTone" in streamLabels:
+	if "NoConnectionTone" in streamLabels:
 		SPLNoConnectionTone = set(streamLabels["NoConnectionTone"])
 
 # Report number of encoders being monitored.

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -2040,9 +2040,13 @@ class AppModule(appModuleHandler.AppModule):
 			self.finish()
 			return
 		try:
-			obj = self.status(self.SPLNextTrackTitle).firstChild
-			# Translators: Presented when there is no information for the next track.
-			nextTrack = _("No next track scheduled or no track is playing") if obj.name is None else obj.name
+			if not splbase.studioAPI(0, 39):
+				# Translators: Presented when there is no information for the next track.
+				nextTrack = _("No track is playing")
+			else:
+				obj = self.status(self.SPLNextTrackTitle).firstChild
+				# Translators: Presented when there is no information for the next track.
+				nextTrack = _("No next track scheduled") if obj.name is None else obj.name
 			# #34 (17.08): normally, player position (name of the internal player in Studio) would not be announced, but might be useful for some broadcasters with mixers.
 			if splconfig.SPLConfig["SayStatus"]["SayStudioPlayerPosition"]:
 				player = self.status(self.SPLNextPlayer).firstChild.name
@@ -2062,9 +2066,13 @@ class AppModule(appModuleHandler.AppModule):
 			self.finish()
 			return
 		try:
-			obj = self.status(self.SPLCurrentTrackTitle).firstChild
-			# Translators: Presented when there is no information for the current track.
-			currentTrack = _("Cannot locate current track information or no track is playing") if obj.name is None else obj.name
+			if not splbase.studioAPI(0, 39):
+				# Translators: Presented when there is no information for the current track.
+				currentTrack = _("No track is playing")
+			else:
+				obj = self.status(self.SPLCurrentTrackTitle).firstChild
+				# Translators: Presented when there is no information for the current track.
+				currentTrack = _("Cannot locate current track information") if obj.name is None else obj.name
 			# #34 (17.08): see the note on next track script above.
 			if splconfig.SPLConfig["SayStatus"]["SayStudioPlayerPosition"]:
 				player = self.status(self.SPLCurrentPlayer).firstChild.name

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -109,12 +109,13 @@ class SPLTrackItem(sysListView32.ListItem):
 
 	# Announce columns based on column number and an optional header for the given column.
 	# 7.0: Add an optional header in order to announce correct header information in columns explorer.
-	def announceColumnContent(self, colNumber, header=None):
+	# #117 (20.02): use visual column order/layout if a track item class doesn't define a custom Columns Explorer list.
+	def announceColumnContent(self, colNumber, header=None, visualColumns=True):
 		# #72: directly fetch on-screen column header (not the in-memory one) by probing column order array from the list (parent).
 		# #65 (18.08): use column header method (at least the method body) provided by the class itself.
 		# This will work properly if the list (parent) is (or recognized as) SysListView32.List.
 		if not header: header = self._getColumnHeaderRaw(self.parent._columnOrderArray[colNumber])
-		columnContent = self._getColumnContentRaw(self.indexOf(header))
+		columnContent = self._getColumnContentRaw(self.indexOf(header) if not visualColumns else colNumber)
 		if columnContent: ui.message(_("{header}: {content}").format(header = header, content = columnContent))
 		else:
 			speech.speakMessage(_("{header}: blank").format(header = header))

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -647,7 +647,7 @@ class AppModule(appModuleHandler.AppModule):
 		super(AppModule, self).__init__(*args, **kwargs)
 		if self.SPLCurVersion < SPLMinVersion:
 			raise RuntimeError("Unsupported version of Studio is running, exiting app module")
-		debugOutput("Using SPL Studio version %s"%self.SPLCurVersion)
+		debugOutput(f"Using SPL Studio version {self.SPLCurVersion}")
 		# #84: if foreground object is defined, this is a true Studio start, otherwise this is an NVDA restart with Studio running.
 		# The latter is possible because app module constructor can run before NVDA finishes initializing, particularly if system focus is located somewhere other than Taskbar.
 		# Note that this is an internal implementation detail and is subject to change without notice.
@@ -714,7 +714,7 @@ class AppModule(appModuleHandler.AppModule):
 		# Only this thread will have privilege of notifying handle's existence.
 		with threading.Lock() as hwndNotifier:
 			splbase._SPLWin = hwnd
-			debugOutput("Studio handle is %s"%hwnd)
+			debugOutput(f"Studio handle is {hwnd}")
 		# #41 (18.04): start background monitor.
 		# 18.08: unless Studio is exiting.
 		try:

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -1195,9 +1195,9 @@ class AppModule(appModuleHandler.AppModule):
 	# Levels indicate which dialog to show (0 = all, 1 = outro, 2 = intro, 3 = microphone).
 
 	def alarmDialog(self, level):
-		if splconfui._configDialogOpened:
+		if splconfui._configDialogOpened or splconfui._alarmDialogOpened:
 			# Translators: Presented when the add-on config dialog is opened.
-			wx.CallAfter(gui.messageBox, _("The add-on settings dialog is opened. Please close the settings dialog first."), translate("Error"), wx.OK|wx.ICON_ERROR)
+			wx.CallAfter(gui.messageBox, _("The add-on settings dialog or another alarm dialog is opened. Please close the opened dialog first."), translate("Error"), wx.OK|wx.ICON_ERROR)
 			return
 		try:
 			d = splconfui.AlarmsCenter(gui.mainFrame, level)

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -2241,6 +2241,11 @@ class AppModule(appModuleHandler.AppModule):
 		self.finish()
 
 	def script_switchProfiles(self, gesture):
+		# #118 (20.02): do not allow profile switching while add-on settings screen is shown.
+		if splconfui._configDialogOpened:
+			# Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+			ui.message(_("Add-on settings dialog is open, cannot switch profiles"))
+			return
 		splconfig.triggerProfileSwitch() if splconfig._triggerProfileActive else splconfig.instantProfileSwitch()
 
 	def script_setPlaceMarker(self, gesture):

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -174,7 +174,7 @@ class SPLTrackItem(sysListView32.ListItem):
 			# #117 (20.02): for track items with no custom Columns Explorer support, refer to visual column layout.
 			# Note that zero-based indexing is still used.
 			column = columnPos
-			header = self._getColumnHeader(column)
+			header = self._getColumnHeaderRaw(column)
 			visualColumns = True
 		if column is not None:
 			# #61 (18.06): pressed once will announce column data, twice will present it in a browse mode window.

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -297,7 +297,8 @@ class SPLStudioTrackItem(SPLTrackItem):
 
 	# Column announcer tweaked for Studio.
 	# 17.04: Allow checked status in 5.1x and later to be announced if this is such a case (vertical column navigation).)
-	def announceColumnContent(self, colNumber, header=None, reportStatus=False):
+	# #117 (20.03): although visual columns flag is specified (consistency with other track items), it isn't used in Studio track items.
+	def announceColumnContent(self, colNumber, header=None, visualColumns=True, reportStatus=False):
 		if not header: header = self._getColumnHeaderRaw(self.parent._columnOrderArray[colNumber])
 		columnContent = self._getColumnContentRaw(self.indexOf(header))
 		status = self.name + " " if reportStatus else ""

--- a/addon/appModules/splstudio/__init__.py
+++ b/addon/appModules/splstudio/__init__.py
@@ -164,12 +164,20 @@ class SPLTrackItem(sysListView32.ListItem):
 			ui.message(_("Column {columnPosition} not found").format(columnPosition= columnPos))
 			return
 		columnPos -= 1
-		header = self.exploreColumns[columnPos]
-		# #103: only concrete implementations will return the correct index.
-		column = self.indexOf(header)
+		try:
+			header = self.exploreColumns[columnPos]
+			# #103: only concrete implementations will return the correct index.
+			column = self.indexOf(header)
+			visualColumns = False
+		except AttributeError:
+			# #117 (20.02): for track items with no custom Columns Explorer support, refer to visual column layout.
+			# Note that zero-based indexing is still used.
+			column = columnPos
+			header = self._getColumnHeader(column)
+			visualColumns = True
 		if column is not None:
 			# #61 (18.06): pressed once will announce column data, twice will present it in a browse mode window.
-			if scriptHandler.getLastScriptRepeatCount() == 0: self.announceColumnContent(column, header=header)
+			if scriptHandler.getLastScriptRepeatCount() == 0: self.announceColumnContent(column, header=header, visualColumns=visualColumns)
 			else:
 				columnContent = self._getColumnContentRaw(column)
 				if columnContent is None:

--- a/addon/appModules/splstudio/splbase.py
+++ b/addon/appModules/splstudio/splbase.py
@@ -35,13 +35,13 @@ def studioIsRunning(justChecking=False):
 def studioAPI(arg, command):
 	if not studioIsRunning(justChecking=True):
 		return
-	debugOutput("Studio API wParem is %s, lParem is %s"%(arg, command))
+	debugOutput(f"Studio API wParem is {arg}, lParem is {command}")
 	val = sendMessage(_SPLWin, 1024, arg, command)
-	debugOutput("Studio API result is %s"%val)
+	debugOutput(f"Studio API result is {val}")
 	return val
 
 # Select a track upon request.
 def selectTrack(trackIndex):
 	studioAPI(-1, 121)
-	debugOutput("selecting track index %s"%trackIndex)
+	debugOutput(f"selecting track index {trackIndex}")
 	studioAPI(trackIndex, 121)

--- a/addon/appModules/splstudio/splconfig.py
+++ b/addon/appModules/splstudio/splconfig.py
@@ -598,12 +598,6 @@ class ConfigHub(ChainMap):
 		# There are two switch flags in use, so make sure to check the highest bit.
 		if switchFlags is not None and not 0 <= switchFlags < 0x4:
 			raise RuntimeError("Profile switch flag out of range")
-		if not appTerminating:
-			from .splconfui import _configDialogOpened
-			if _configDialogOpened:
-				# Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-				ui.message(_("Add-on settings dialog is open, cannot switch profiles"))
-				return
 		self.swapProfiles(prevProfile, newProfile)
 		if appTerminating: return
 		# Set the prev flag manually.

--- a/addon/appModules/splstudio/splconfig.py
+++ b/addon/appModules/splstudio/splconfig.py
@@ -632,7 +632,7 @@ class ConfigHub(ChainMap):
 			raise RuntimeError("Instant switch flag is already on")
 		elif switchType == "timed" and self.timedSwitchProfileActive:
 			raise RuntimeError("Timed switch flag is already on")
-		spldebugging.debugOutput("Profile switching start: type = %s, previous profile is %s, new profile is %s"%(switchType, prevProfile, newProfile))
+		spldebugging.debugOutput(f"Profile switching start: type = {switchType}, previous profile is {prevProfile}, new profile is {newProfile}")
 		self.switchProfile(prevProfile, newProfile, switchFlags=self._switchProfileFlags ^ self._profileSwitchFlags[switchType])
 		# 8.0: Cache the new profile.
 		global _SPLCache
@@ -647,7 +647,7 @@ class ConfigHub(ChainMap):
 			raise RuntimeError("Instant switch flag is already off")
 		elif switchType == "timed" and not self.timedSwitchProfileActive:
 			raise RuntimeError("Timed switch flag is already off")
-		spldebugging.debugOutput("Profile switching end: type = %s, previous profile is %s, new profile is %s"%(switchType, prevProfile, newProfile))
+		spldebugging.debugOutput(f"Profile switching end: type = {switchType}, previous profile is {prevProfile}, new profile is {newProfile}")
 		self.switchProfile(prevProfile, newProfile, switchFlags=self._switchProfileFlags ^ self._profileSwitchFlags[switchType])
 
 	# Used from config dialog and other places.
@@ -791,7 +791,7 @@ def initProfileTriggers():
 			try:
 				SPLConfig.profileIndexByName(profile)
 			except ValueError:
-				spldebugging.debugOutput("profile %s does not exist"%profile)
+				spldebugging.debugOutput(f"profile {profile} does not exist")
 				nonexistent.append(profile)
 				del profileTriggers[profile]
 		if len(nonexistent):

--- a/addon/appModules/splstudio/splconfui.py
+++ b/addon/appModules/splstudio/splconfui.py
@@ -850,7 +850,7 @@ class AlarmsPanel(ProfileSpecificSettingsBasePanel):
 		curProfile["MicrophoneAlarm"]["MicAlarm"] = self.micAlarmEntry.GetValue()
 		curProfile["MicrophoneAlarm"]["MicAlarmInterval"] = self.micIntervalEntry.GetValue()
 		self._curProfileSettings.clear()
-		# #80 (18.10.2/18.09.4-LTS): don't just nullify profile setings, otherwise attribute and type error excpetions may arise.
+		# #80 (18.10.2/18.09.4-LTS): don't just nullify profile settings, otherwise attribute and type error exceptions may arise.
 		if not _configApplyOnly: self._curProfileSettings = None
 
 	def onDiscard(self):

--- a/addon/appModules/splstudio/splconfui.py
+++ b/addon/appModules/splstudio/splconfui.py
@@ -673,7 +673,6 @@ class AlarmsCenter(wx.Dialog):
 		if inst:
 			return
 		# Use a weakref so the instance can die.
-		import weakref
 		AlarmsCenter._instance = weakref.ref(self)
 
 		# Now the actual alarm dialog code.

--- a/addon/appModules/splstudio/splconfui.py
+++ b/addon/appModules/splstudio/splconfui.py
@@ -1607,9 +1607,12 @@ class SPLConfigDialog(gui.MultiCategorySettingsDialog):
 
 	def makeSettings(self, settingsSizer):
 		super(SPLConfigDialog, self).makeSettings(settingsSizer)
+		global _configDialogOpened
 		# #40 (17.12): respond to app terminate notification by closing this dialog.
 		# All top-level dialogs will be affected by this, and apart from this one, others will check for flags also.
 		splactions.SPLActionAppTerminating.register(self.onAppTerminate)
+		# 20.02: let everyone know add-on settings is opened.
+		_configDialogOpened = True
 
 	def onOk(self, evt):
 		super(SPLConfigDialog,  self).onOk(evt)

--- a/addon/appModules/splstudio/splconfui.py
+++ b/addon/appModules/splstudio/splconfui.py
@@ -1545,9 +1545,9 @@ class ResetDialog(wx.Dialog):
 			if self.resetEncodersCheckbox.Value:
 				if os.path.exists(os.path.join(globalVars.appArgs.configPath, "splStreamLabels.ini")):
 					os.remove(os.path.join(globalVars.appArgs.configPath, "splStreamLabels.ini"))
-				if "globalPlugins.splUtils.encoders" in sys.modules:
-					import globalPlugins.splUtils.encoders
-					globalPlugins.splUtils.encoders.cleanup()
+				if "appModules.splengine.encoders" in sys.modules:
+					import appModules.splengine.encoders
+					appModules.splengine.encoders.cleanup()
 			_configDialogOpened = False
 			# Translators: A dialog message shown when settings were reset to defaults.
 			wx.CallAfter(gui.messageBox, _("Successfully applied default add-on settings."),

--- a/addon/appModules/splstudio/spldebugging.py
+++ b/addon/appModules/splstudio/spldebugging.py
@@ -4,11 +4,9 @@
 # Provides debug output and other diagnostics probes.
 
 from logHandler import log
-
 import globalVars
 SPLDebuggingFramework = globalVars.appArgs.debugLogging
 
 def debugOutput(message):
 	if SPLDebuggingFramework:
-		log.debug("SPL: %s"%message)
-
+		log.debug(f"SPL: {message}")

--- a/addon/appModules/splstudio/splmisc.py
+++ b/addon/appModules/splstudio/splmisc.py
@@ -301,7 +301,7 @@ def cartExplorerInit(StudioTitle, cartFiles=None, refresh=False, carts=None):
 		if not refresh and not os.path.isfile(cartFile): # Cart explorer will fail if whitespaces are in the beginning or at the end of a user name.
 			faultyCarts = True
 			continue
-		debugOutput("examining carts from file %s"%cartFile)
+		debugOutput(f"examining carts from file {cartFile}")
 		cartTimestamp = os.path.getmtime(cartFile)
 		if refresh and _cartEditTimestamps[cartFiles.index(f)] == cartTimestamp:
 			debugOutput("no changes to cart bank, skipping")
@@ -313,9 +313,9 @@ def cartExplorerInit(StudioTitle, cartFiles=None, refresh=False, carts=None):
 		# The below method will just check for string length, which is faster than looking for specific substring.
 		_populateCarts(carts, cl[1], mod if mod != "main" else "", standardEdition=carts["standardLicense"], refresh=refresh) # See the comment for _populate method above.
 		if not refresh:
-			debugOutput("carts processed so far: %s"%(len(carts)-1))
+			debugOutput(f"carts processed so far: {(len(carts)-1)}")
 	carts["faultyCarts"] = faultyCarts
-	debugOutput("total carts processed: %s"%(len(carts)-2))
+	debugOutput(f"total carts processed: {(len(carts)-2)}")
 	return carts
 
 # Refresh carts upon request.

--- a/addon/appModules/tracktool.py
+++ b/addon/appModules/tracktool.py
@@ -81,7 +81,7 @@ class AppModule(appModuleHandler.AppModule):
 
 	def chooseNVDAObjectOverlayClasses(self, obj, clsList):
 		import controlTypes
-		if obj.windowClassName in ("TListView", "TTntListView.UnicodeClass"):
+		if obj.windowClassName == "TTntListView.UnicodeClass":
 			if obj.role == controlTypes.ROLE_LISTITEM:
 				clsList.insert(0, TrackToolItem)
 			elif obj.role == controlTypes.ROLE_LIST:

--- a/addon/doc/de/readme.md
+++ b/addon/doc/de/readme.md
@@ -369,6 +369,8 @@ die oben aufgeführten Touch-Befehle, um Befehle auszuführen.
 * When trying to switch between active profile and an instant profile via
   SPL Assistant (F12), NVDA will present a message if attempting to do so
   while add-on settings screen is open.
+* In encoders, NVDA will no longer forget to apply no connection tone
+  setting for encoders when NVDA is restarted.
 
 ## Version 20.01
 

--- a/addon/doc/de/readme.md
+++ b/addon/doc/de/readme.md
@@ -19,8 +19,7 @@ Quellcodeverzeichnis der Erweiterung auf Github.
 
 WICHTIGE HINWEISE:
 
-* This add-on requires NVDA 2019.3 or later and StationPlaylist suite 5.20
-  or later.
+* This add-on requires StationPlaylist suite 5.20 or later.
 * Wenn Sie Windows 8 oder höher verwenden, setzen Sie die Reduzierung der
   Lautstärke anderer Audioquellen auf "nie" im Dialog Sprachausgabe im
   NVDA-Einstellungsmenü.
@@ -51,11 +50,19 @@ angegeben.
   Sekunden bis zur vollen Stunde angesagt.
 * Alt+NVDA+1 (mit zwei Fingern nach rechts wischen im SPL-Touch-Modus) aus
   dem Studio-Fenster: Öffnet den Dialog zum Einstellen des Titelendes.
+* Alt+NVDA+1 from Creator's Playlist Editor window: Announces scheduled time
+  for the loaded playlist.
 * Alt+NVDA+2 (mit zwei Fingern nach links wischen im SPL-Touchmodus) aus dem
   Studio-Fenster: Öffnet den Einstellungsdialog für den Titel-Intro-Alarm.
+* Alt+NVDA+2 from Creator's Playlist Editor window: Announces total playlist
+  duration.
 * Alt+NVDA+3 aus dem Studio-Fenster: legt den Cart-Explorer fest, um die
   Zuordnung von Carts zu lernen.
+* Alt+NVDA+3 from Creator's Playlist Editor window: Announces when the
+  selected track is scheduled to play.
 * Alt+NVDA+4 aus dem Studio-Fenster: Öffnet den Mikrofonalarm-Dialog.
+* Alt+NVDA+4 from Creator's Playlist Editor window: Announces rotation and
+  category associated with the loaded playlist.
 * STRG+NVDA+f aus dem Studio-Fenster: Öffnet einen Dialog, um einen Titel
   basierend auf Künstler oder Titelbezeichnung zu finden. Drücken Sie
   NVDA+F3, um vorwärts zu suchen oder NVDA+Umschalt+F3, um rückwärts zu
@@ -66,15 +73,17 @@ angegeben.
 * Strg+Alt+Pfeiltaste nach links/rechts (während Sie sich auf einen Track im
   Studio, Creator und Track Tool befinden): Ankündigung der
   vorherigen/nächsten Track-Spalte.
-* Strg+Alt+Pfeiltaste nach oben/unten (während Sie sich nur auf einen Track
-  in Studio befinden): Wechseln Sie zum vorherigen oder nächsten Track und
-  kündigen Sie bestimmte Spalten an (nicht verfügbar im Add-on 15.x).
+* Control+Alt+Home/End (while focused on a track in Studio, Creator, and
+  Track Tool): Announce first/last track column.
+* Control+Alt+up/down arrow (while focused on a track in Studio only): Move
+  to previous or next track and announce specific columns.
 * Strg+NVDA+1 bis 0 (während sie sich auf einen Track im Studio, Creator und
   Track Tool befinden): Ankündigung von Spalteninhalten für eine bestimmte
   Spalte. Wenn Sie diesen Befehl zweimal drücken, werden
   Spalteninformationen in einem Fenster des Lesemodus angezeigt.
-* Strg+NVDA+Minus (Bindestrich) in Studio): Zeigt Daten für alle Spalten in
-  einer Spur in einem Fenster des Lesemodus an.
+* Control+NVDA+- (hyphen while focused on a track in Studio, Creator, and
+  Track Tool): display data for all columns in a track on a browse mode
+  window.
 * Alt+NVDA+C während der Fokus auf einen Track (nur Studio): Meldet
   Track-Kommentare, falls vorhanden.
 * Alt+NVDA+0 aus dem Studio-Fenster: Öffnet den Konfigurationsdialog der
@@ -334,6 +343,32 @@ verwenden und NVDA 2012.3 oder höher installiert haben, können Sie einige
 Studio-Befehle über den Touchscreen ausführen. Tippen Sie zunächst einmal
 mit drei Fingern, um in den SPL-Touchmodus zu wechseln. Verwenden Sie dann
 die oben aufgeführten Touch-Befehle, um Befehle auszuführen.
+
+## Version 20.02
+
+* Initial support for StationPlaylist Creator's Playlist Editor.
+* Added Alt+NVDA+number row commands to announce various status information
+  in Playlist Editor. These include date and time for the playlist (1),
+  total playlist duration (2), when the selected track is scheduled to play
+  (3), and rotation and category (4).
+* While focused on a track in Creator and Track Tool (except in Creator's
+  Playlist Editor), pressing Control+NVDA+Dash will display data for all
+  columns on a browse mode window.
+* If NVDA Recognizes a track list item with less than 10 columns, NVDA will
+  no longer announce headers for nonexistent columns if Control+NVDA+number
+  row for out of range column is pressed.
+* In creator, NVDA will no longer announce column information if
+  Control+NVDA+number row keys are pressed while focused on places other
+  than track list.
+* When a track is playing, NVDA will no longer announce "no track is
+  playing" if obtaining information about current and next tracks via SPL
+  Assistant or SPL Controller.
+* If an alarm options dialog (intro, outro, microphone) is open, NVDA will
+  no longer appear to do nothing or play error tone if attempting to open a
+  second instance of any alarm dialog.
+* When trying to switch between active profile and an instant profile via
+  SPL Assistant (F12), NVDA will present a message if attempting to do so
+  while add-on settings screen is open.
 
 ## Version 20.01
 

--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -20,7 +20,7 @@ repositorio del código fuente del complemento.
 
 NOTAS IMPORTANTES:
 
-* This add-on requires StationPlaylist suite 5.20 or later.
+* Este complemento requiere StationPlaylist Suite 5.20 o posterior.
 * Si utilizas Windows 8 o posterior, para una mejor experiencia, deshabilita
   el modo atenuación de audio.
 * A partir de 2018, los [registros de cambios para versiones antiguas][5] se
@@ -50,20 +50,22 @@ contrario.
   anunciará los minutos y segundos hasta la hora.
 * Alt+NVDA+1 (deslizar dos dedos a la derecha en modo SPL) desde la ventana
   de Studio: abre el diálogo de opciones de fin de pista.
-* Alt+NVDA+1 from Creator's Playlist Editor window: Announces scheduled time
-  for the loaded playlist.
+* Alt+NVDA+1 desde la ventana del editor de listas de reproducción de
+  Creator: anuncia la hora programada de la lista de reproducción cargada.
 * Alt+NVDA+2 (deslizar  con dos dedos hacia a la izquierda en modo táctil
   para SPL) desde la ventana Studio: Abre el diálogo de configuración de
   alarma de intro de la canción.
-* Alt+NVDA+2 from Creator's Playlist Editor window: Announces total playlist
-  duration.
+* Alt+NVDA+2 desde la ventana del editor de listas de reproducción de
+  Creator: anuncia la duración total de la lista de reproducción.
 * Alt+NVDA+3 desde la ventana Studio: activa o desactiva el explorador de
   cart para aprender las asignaciones de cart.
-* Alt+NVDA+3 from Creator's Playlist Editor window: Announces when the
-  selected track is scheduled to play.
+* Alt+NVDA+3 desde la ventana del editor de listas de reproducción de
+  Creator: indica para cuándo se ha programado la reproducción de la pista
+  seleccionada.
 * Alt+NVDA+4 desde la ventana Studio: Abre el diálogo alarma del micrófono.
-* Alt+NVDA+4 from Creator's Playlist Editor window: Announces rotation and
-  category associated with the loaded playlist.
+* Alt+NVDA+4 desde la ventana del editor de listas de reproducción de
+  Creator: anuncia la rotación y categoría asociadas con la lista de
+  reproducción cargada.
 * Control+NVDA+f desde la ventana de Studio: Abre un diálogo para encontrar
   una pista sobre la base del artista o del nombre de la canción. Pulsa
   NVDA+F3 para buscar hacia adelante o NVDA+Shift+F3 para buscar hacia
@@ -75,17 +77,18 @@ contrario.
 * Control+Alt+flecha derecha o izquierda (mientras se enfoca una pista en
   Studio, Creator, o Track Tool): anuncia la columna de la pista siguiente o
   anterior.
-* Control+Alt+Home/End (while focused on a track in Studio, Creator, and
-  Track Tool): Announce first/last track column.
-* Control+Alt+up/down arrow (while focused on a track in Studio only): Move
-  to previous or next track and announce specific columns.
+* Control+Alt+inicio o fin (mientras se enfoca una pista en Studio, Creator,
+  o Track Tool): anuncia la primera o última columna de la pista.
+* Control+Alt+flecha abajo/arriba (mientras se enfoque una pista sólo en
+  Studio): se mueve a la pista siguiente o anterior y anuncia columnas
+  específicas.
 * Control+NVDA+1 a 0 (mientras se enfoque una pista en Studio, Creator o
   Track Tool): Anuncia el contenido de la columna especificada. Pulsando
   este atajo dos veces mostrará la información de la columna en una ventana
   para modo navegación.
-* Control+NVDA+- (hyphen while focused on a track in Studio, Creator, and
-  Track Tool): display data for all columns in a track on a browse mode
-  window.
+* Control+NVDA+- (guión cuando una pista tiene el foco en Studio, Creator y
+  Track Tool): mostrar datos de todas las columnas de una pista en una
+  ventana para modo navegación.
 * Alt+NVDA+C mientras se enfoca una pista (sólo Studio): anuncia los
   comentarios de pista si los hay.
 * Alt+NVDA+0 desde la ventana Studio: abre el diálogo de configuración del
@@ -340,31 +343,36 @@ realizar algunas órdenes de Studio desde la pantalla táctil. Primero utiliza
 un toque con tres dedos para cambiar a modo SPL, entonces utiliza las
 órdenes táctiles listadas arriba para llevar a cabo tareas.
 
-## Version 20.02
+## Versión 20.02
 
-* Initial support for StationPlaylist Creator's Playlist Editor.
-* Added Alt+NVDA+number row commands to announce various status information
-  in Playlist Editor. These include date and time for the playlist (1),
-  total playlist duration (2), when the selected track is scheduled to play
-  (3), and rotation and category (4).
-* While focused on a track in Creator and Track Tool (except in Creator's
-  Playlist Editor), pressing Control+NVDA+Dash will display data for all
-  columns on a browse mode window.
-* If NVDA Recognizes a track list item with less than 10 columns, NVDA will
-  no longer announce headers for nonexistent columns if Control+NVDA+number
-  row for out of range column is pressed.
-* In creator, NVDA will no longer announce column information if
-  Control+NVDA+number row keys are pressed while focused on places other
-  than track list.
-* When a track is playing, NVDA will no longer announce "no track is
-  playing" if obtaining information about current and next tracks via SPL
-  Assistant or SPL Controller.
-* If an alarm options dialog (intro, outro, microphone) is open, NVDA will
-  no longer appear to do nothing or play error tone if attempting to open a
-  second instance of any alarm dialog.
-* When trying to switch between active profile and an instant profile via
-  SPL Assistant (F12), NVDA will present a message if attempting to do so
-  while add-on settings screen is open.
+* Soporte inicial para el editor de listas de reproducción de
+  StationPlaylist creator.
+* Se han añadido las órdenes alt+NVDA+fila numérica para anunciar diversa
+  información de estado en el editor de listas de reproducción. Esto incluye
+  fecha y hora de la lista de reproducción (1), duración total de la lista
+  de reproducción (2), para cuándo se ha programado la reproducción de la
+  pista seleccionada (3), y rotación y categoría (4).
+* Mientras una pista esté enfocada en Creator y Track Tool (exceptuando el
+  editor de listas de reproducción de Creator), pulsar control+NVDA+guión
+  mostrará los datos para todas las columnas en una ventana de modo
+  exploración.
+* Si NVDA reconoce un elemento de lista de pista con menos de 10 columnas,
+  ya no anunciará encabezados de columnas inexistentes si se pulsa
+  control+NVDA+fila numérica con columnas fuera de rango.
+* En Creator, NVDA ya no anunciará información de columna si se pulsan las
+  teclas control+NVDA+fila numérica mientras el foco se encuentre en lugares
+  distintos a la lista de pistas.
+* Cuando se esté reproduciendo una pista, NVDA ya no anunciará "No hay pista
+  en reproducción" si se obtiene información sobre las pistas actual y
+  siguiente mediante el asistente o el controlador de SPL.
+* Si hay abierto un diálogo de opciones de alarma (introducción, salida o
+  micrófono), NVDA ya no parecerá hacer nada ni reproducirá tonos de error
+  si se intenta abrir una segunda instancia de cualquier diálogo de alarma.
+* Al intentar alternar entre el perfil activo y un perfil instantáneo
+  mediante el asistente de SPL (f12), NVDA presentará un mensaje si se
+  pretende hacer con el diálogo de opciones del complemento abierto.
+* En los codificadores, NVDA ya no olvidará aplicar el ajuste del tono que
+  indica que no hay conexión al reiniciarlo.
 
 ## Versión 20.01
 

--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -20,8 +20,7 @@ repositorio del código fuente del complemento.
 
 NOTAS IMPORTANTES:
 
-* Este complemento requiere de NVDA 2019.3 o posterior y StationPlaylist
-  Suite 5.20 o posterior.
+* This add-on requires StationPlaylist suite 5.20 or later.
 * Si utilizas Windows 8 o posterior, para una mejor experiencia, deshabilita
   el modo atenuación de audio.
 * A partir de 2018, los [registros de cambios para versiones antiguas][5] se
@@ -51,12 +50,20 @@ contrario.
   anunciará los minutos y segundos hasta la hora.
 * Alt+NVDA+1 (deslizar dos dedos a la derecha en modo SPL) desde la ventana
   de Studio: abre el diálogo de opciones de fin de pista.
+* Alt+NVDA+1 from Creator's Playlist Editor window: Announces scheduled time
+  for the loaded playlist.
 * Alt+NVDA+2 (deslizar  con dos dedos hacia a la izquierda en modo táctil
   para SPL) desde la ventana Studio: Abre el diálogo de configuración de
   alarma de intro de la canción.
+* Alt+NVDA+2 from Creator's Playlist Editor window: Announces total playlist
+  duration.
 * Alt+NVDA+3 desde la ventana Studio: activa o desactiva el explorador de
   cart para aprender las asignaciones de cart.
+* Alt+NVDA+3 from Creator's Playlist Editor window: Announces when the
+  selected track is scheduled to play.
 * Alt+NVDA+4 desde la ventana Studio: Abre el diálogo alarma del micrófono.
+* Alt+NVDA+4 from Creator's Playlist Editor window: Announces rotation and
+  category associated with the loaded playlist.
 * Control+NVDA+f desde la ventana de Studio: Abre un diálogo para encontrar
   una pista sobre la base del artista o del nombre de la canción. Pulsa
   NVDA+F3 para buscar hacia adelante o NVDA+Shift+F3 para buscar hacia
@@ -68,15 +75,17 @@ contrario.
 * Control+Alt+flecha derecha o izquierda (mientras se enfoca una pista en
   Studio, Creator, o Track Tool): anuncia la columna de la pista siguiente o
   anterior.
-* Control+Alt+flecha abajo/arriba (mientras se enfoque una pista sólo en
-  Studio): Mueven a la pista siguiente o anterior y anuncian columnas
-  específicas (no disponible en el complemento 15.x).
+* Control+Alt+Home/End (while focused on a track in Studio, Creator, and
+  Track Tool): Announce first/last track column.
+* Control+Alt+up/down arrow (while focused on a track in Studio only): Move
+  to previous or next track and announce specific columns.
 * Control+NVDA+1 a 0 (mientras se enfoque una pista en Studio, Creator o
   Track Tool): Anuncia el contenido de la columna especificada. Pulsando
   este atajo dos veces mostrará la información de la columna en una ventana
   para modo navegación.
-* Control+NVDA+- (guión, en Studio): mostrar datos de todas las columnas de
-  una pista en una ventana para modo navegación.
+* Control+NVDA+- (hyphen while focused on a track in Studio, Creator, and
+  Track Tool): display data for all columns in a track on a browse mode
+  window.
 * Alt+NVDA+C mientras se enfoca una pista (sólo Studio): anuncia los
   comentarios de pista si los hay.
 * Alt+NVDA+0 desde la ventana Studio: abre el diálogo de configuración del
@@ -330,6 +339,32 @@ Windows 8 o posterior y tienes NVDA 2012.3 o posterior instalado, puedes
 realizar algunas órdenes de Studio desde la pantalla táctil. Primero utiliza
 un toque con tres dedos para cambiar a modo SPL, entonces utiliza las
 órdenes táctiles listadas arriba para llevar a cabo tareas.
+
+## Version 20.02
+
+* Initial support for StationPlaylist Creator's Playlist Editor.
+* Added Alt+NVDA+number row commands to announce various status information
+  in Playlist Editor. These include date and time for the playlist (1),
+  total playlist duration (2), when the selected track is scheduled to play
+  (3), and rotation and category (4).
+* While focused on a track in Creator and Track Tool (except in Creator's
+  Playlist Editor), pressing Control+NVDA+Dash will display data for all
+  columns on a browse mode window.
+* If NVDA Recognizes a track list item with less than 10 columns, NVDA will
+  no longer announce headers for nonexistent columns if Control+NVDA+number
+  row for out of range column is pressed.
+* In creator, NVDA will no longer announce column information if
+  Control+NVDA+number row keys are pressed while focused on places other
+  than track list.
+* When a track is playing, NVDA will no longer announce "no track is
+  playing" if obtaining information about current and next tracks via SPL
+  Assistant or SPL Controller.
+* If an alarm options dialog (intro, outro, microphone) is open, NVDA will
+  no longer appear to do nothing or play error tone if attempting to open a
+  second instance of any alarm dialog.
+* When trying to switch between active profile and an instant profile via
+  SPL Assistant (F12), NVDA will present a message if attempting to do so
+  while add-on settings screen is open.
 
 ## Versión 20.01
 

--- a/addon/doc/es/readme.md
+++ b/addon/doc/es/readme.md
@@ -3,8 +3,9 @@
 * Autores: Geoff Shang, Joseph Lee y otros colaboradores
 * Descargar [Versión estable][1]
 * Descargar [versión de desarrollo][2]
-* NVDA compatibility: 2019.3 and beyond
-* Download [older version][6] compatible with NVDA 2019.2.1 and earlier
+* Compatibilidad con NVDA: 2019.3 y versiones posteriores
+* Descargar [versión más antigua][6] compatible con NVDA 2019.2.1 y
+  versiones anteriores
 
 Este paquete de complementos proporciona una utilización mejorada de Station
 Playlist Studio y otras aplicaciones de StationPlaylist, así como utilidades
@@ -19,13 +20,13 @@ repositorio del código fuente del complemento.
 
 NOTAS IMPORTANTES:
 
-* This add-on requires NVDA 2019.3 or later and StationPlaylist suite 5.20
-  or later.
+* Este complemento requiere de NVDA 2019.3 o posterior y StationPlaylist
+  Suite 5.20 o posterior.
 * Si utilizas Windows 8 o posterior, para una mejor experiencia, deshabilita
   el modo atenuación de audio.
-* Starting from 2018, [changelogs for old add-on releases][5] will be found
-  on GitHub. This add-on readme will list changes from version 17.08 (2017
-  onwards).
+* A partir de 2018, los [registros de cambios para versiones antiguas][5] se
+  encontrarán en GitHub. Este léeme del complemento listará cambios desde la
+  versión 17.08 (2017 en adelante).
 * Ciertas características del complemento no funcionarán bajo algunas
   condiciones, incluyendo la ejecución de NVDA en modo seguro.
 * Debido a limitaciones técnicas, no puedes instalar ni utilizar este
@@ -330,9 +331,9 @@ realizar algunas órdenes de Studio desde la pantalla táctil. Primero utiliza
 un toque con tres dedos para cambiar a modo SPL, entonces utiliza las
 órdenes táctiles listadas arriba para llevar a cabo tareas.
 
-## Version 20.01
+## Versión 20.01
 
-* NVDA 2019.3 or later is required due to extensive use of Python 3.
+* Se requiere NVDA 2019.3 o posterior debido al uso extenso de Python 3.
 
 ## Versión 19.11.1/18.09.13-LTS
 

--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -362,6 +362,8 @@ ci-dessus pour exécuter des commandes.
 * When trying to switch between active profile and an instant profile via
   SPL Assistant (F12), NVDA will present a message if attempting to do so
   while add-on settings screen is open.
+* In encoders, NVDA will no longer forget to apply no connection tone
+  setting for encoders when NVDA is restarted.
 
 ## Version 20.01
 

--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -18,8 +18,7 @@ référentiel de l'extension.
 
 NOTES IMPORTANTES :
 
-* This add-on requires NVDA 2019.3 or later and StationPlaylist suite 5.20
-  or later.
+* This add-on requires StationPlaylist suite 5.20 or later.
 * Si vous utilisez Windows 8 ou ultérieur, pour une meilleure expérience,
   désactiver le Mode d'atténuation audio.
 * Starting from 2018, [changelogs for old add-on releases][5] will be found
@@ -49,13 +48,21 @@ contraire.
   annoncer les minutes et les secondes jusqu'au début de l'heure.
 * Alt+NVDA+1 (glissement à deux doigts vers la droite en mode SPL) depuis la
   fenêtre de Studio: Ouvre la boîte de dialogue  paramètre fin de piste.
+* Alt+NVDA+1 from Creator's Playlist Editor window: Announces scheduled time
+  for the loaded playlist.
 * Alt+NVDA+2 (glissement à deux doigts vers la gauche en mode tactile SPL)
   depuis la fenêtre de Studio: Ouvre la boîte de dialogue  paramètre alarme
   chanson intro.
+* Alt+NVDA+2 from Creator's Playlist Editor window: Announces total playlist
+  duration.
 * Alt+NVDA+3 depuis la fenêtre de Studio : Basculer l'explorateur de chariot
   pour apprendre les assignations de chariot.
+* Alt+NVDA+3 from Creator's Playlist Editor window: Announces when the
+  selected track is scheduled to play.
 * Alt+NVDA+4 depuis la fenêtre de Studio : Ouvre le dialogue alarme
   microphone.
+* Alt+NVDA+4 from Creator's Playlist Editor window: Announces rotation and
+  category associated with the loaded playlist.
 * Control+NVDA+f from Studio window: Opens a dialog to find a track based on
   artist or song name. Press NVDA+F3 to find forward or NVDA+Shift+F3 to
   find backward.
@@ -66,16 +73,18 @@ contraire.
 * Contrôle+Alt+flèche gauche/droite (alors que  a été mis en focus sur une
   piste dans Studio, Creator, et l'Outil de piste): Annoncer colonne de
   piste précédente/suivante.
-* Contrôle+Alt+flèche haut/bas (alors que  a été mis en focus sur une piste
-  dans Studio): Déplacer vers la piste précédente ou suivante et annoncer
-  des colonnes spécifiques (indisponible dans l'extension 15.x).
+* Control+Alt+Home/End (while focused on a track in Studio, Creator, and
+  Track Tool): Announce first/last track column.
+* Control+Alt+up/down arrow (while focused on a track in Studio only): Move
+  to previous or next track and announce specific columns.
 * Contrôle+NVDA+1 à 0 (alors que  a été mis en focus sur une piste dans
   Studio, Creator et l'Outil de piste): Annoncer le contenu de la colonne
   pour une colonne spécifiée. Si vous appuyez deux fois sur cette commande,
   les informations de colonne s'affichent dans une fenêtre en mode
   navigation.
-* Contrôle+NVDA+- (tiret dans Studio): affiche les données pour toutes les
-  colonnes d'une piste dans une fenêtre en mode navigation.
+* Control+NVDA+- (hyphen while focused on a track in Studio, Creator, and
+  Track Tool): display data for all columns in a track on a browse mode
+  window.
 * Alt+NVDA+C alors que  a été mis en focus sur une piste (Studio
   uniquement): annonce les commentaires de piste le cas échéant.
 * Alt+NVDA+0 depuis la fenêtre de Studio : Ouvre le dialogue de
@@ -327,6 +336,32 @@ ultérieure installé, vous pouvez exécuter certaines commandes Studio depuis
 un écran tactile. Tout d'abord utiliser une tape à trois doigts pour
 basculer en mode SPL, puis utilisez les commandes tactile énumérées
 ci-dessus pour exécuter des commandes.
+
+## Version 20.02
+
+* Initial support for StationPlaylist Creator's Playlist Editor.
+* Added Alt+NVDA+number row commands to announce various status information
+  in Playlist Editor. These include date and time for the playlist (1),
+  total playlist duration (2), when the selected track is scheduled to play
+  (3), and rotation and category (4).
+* While focused on a track in Creator and Track Tool (except in Creator's
+  Playlist Editor), pressing Control+NVDA+Dash will display data for all
+  columns on a browse mode window.
+* If NVDA Recognizes a track list item with less than 10 columns, NVDA will
+  no longer announce headers for nonexistent columns if Control+NVDA+number
+  row for out of range column is pressed.
+* In creator, NVDA will no longer announce column information if
+  Control+NVDA+number row keys are pressed while focused on places other
+  than track list.
+* When a track is playing, NVDA will no longer announce "no track is
+  playing" if obtaining information about current and next tracks via SPL
+  Assistant or SPL Controller.
+* If an alarm options dialog (intro, outro, microphone) is open, NVDA will
+  no longer appear to do nothing or play error tone if attempting to open a
+  second instance of any alarm dialog.
+* When trying to switch between active profile and an instant profile via
+  SPL Assistant (F12), NVDA will present a message if attempting to do so
+  while add-on settings screen is open.
 
 ## Version 20.01
 

--- a/addon/doc/gl/readme.md
+++ b/addon/doc/gl/readme.md
@@ -362,6 +362,8 @@ listadas arriba para realizar ordes.
 * ao tentar cambiar entre o perfil activo e un perfil instantáneo a través
   de SPL Assitant (F12), NVDA presentará unha mensaxe se se intenta facer
   cando a pantalla de opcións do complemento estea aberta.
+* In encoders, NVDA will no longer forget to apply no connection tone
+  setting for encoders when NVDA is restarted.
 
 ## Versión 20.01
 

--- a/addon/doc/gl/readme.md
+++ b/addon/doc/gl/readme.md
@@ -3,8 +3,9 @@
 * Autores: Geoff Shang, Joseph Lee e outros colaboradores
 * Descargar [versión estable][1]
 * Descargar [versión de desenvolvemento][2]
-* NVDA compatibility: 2019.3 and beyond
-* Download [older version][6] compatible with NVDA 2019.2.1 and earlier
+* Compatibilidade con NVDA: 2019.3 en diante
+* Descargar [versión máis antiga][6] compatible con NVDA 2019.2.1 e
+  anteriores
 
 Este paquete de complementos proporciona unhha utilización mellorada do
 Station Playlist Studio e outras apps de Station Playlist, así como
@@ -19,13 +20,12 @@ repositorio do código fonte.
 
 NOTAS IMPORTANTES:
 
-* This add-on requires NVDA 2019.3 or later and StationPlaylist suite 5.20
-  or later.
+* Este complemento require o paquete StationPlaylist 5.20 ou posterior.
 * Se usas o Windows 8 ou posterior, para unha mellor experiencia,
   deshabilita o modo atenuación de audio.
-* Starting from 2018, [changelogs for old add-on releases][5] will be found
-  on GitHub. This add-on readme will list changes from version 17.08 (2017
-  onwards).
+* A partires de 2018, os [rexistros de cambios para versións vellas][5]
+  atoparanse en GitHub. Este readme do complemento listará cambios dende a
+  versión 17.08 (2017 en diante).
 * Certas características do complemento non funcionarán baixo algunhas
   condicións, incluindo a execución do NVDA en modo seguro.
 * Debido a limitacións técnicas, non podes instalar nin usar este
@@ -50,12 +50,20 @@ contrario.
   segundos ata a hora.
 * Alt+NVDA+1 (deslizamento con dous dedos cara a dereita no modo tactil SPL)
   dende a ventá do Studio: Abre o diálogo de opcións do remate da pista.
+* Alt+NVDA+1 dende a ventá do Editor de Listas de Reprodución de Creator:
+  anuncia o tempo programado para a lista cargada.
 * Alt+NVDA+2 (deslizamento con dous dedos cara a esquerda no modo tactil
   SPL) dende a ventá do Studio: Abre o diálogo de configuración da alarma de
   intro da canción.
+* Alt+NVDA+2 dende a ventá de Editor de Listas de Reprodución de Creator:
+  Anuncia a duración de toda a lista.
 * Alt+NVDA+3 dende a ventá Studio:  conmuta o explorador de cart para
   deprender  as asignacións das cart.
+* Alt+NVDA+2 dende a ventá de Editor de Listas de Reprodución de Creator:
+  Anuncia cando está a pista seleccionada programada para reproducirse.
 * Alt+NVDA+4 dende a ventá do Studio: Abre o diálogo de alarma do micrófono.
+* Alt+NVDA+2 dende a ventá de Editor de Listas de Reprodución de Creator:
+  Anuncia rotación e e categoría asociadas coa lista cargada.
 * Control+NVDA+f dende a ventá do Studio: Abre un diálogo para procurar unha
   pista baseada no artista ou no nome da canción. Preme NVDA+F3 para
   procurar cara adiante ou NVDA+Shift+F3 para procurar cara atrás.
@@ -66,15 +74,18 @@ contrario.
 * Control+Alt+frechas dereita e esquerda (mentres se enfoca nunha pista no
   Studio, Creator ou TrackTool): anuncia a columna da pista seguinte ou
   anterior.
-* Control+Alt+frecha abaixo/arriba (mentres se enfoque unha pista só en
-  Studio): Moven á pista seguinte ou anterior e anuncian columnas
-  específicas (non dispoñible no complemento 15.x).
+* Control+Alt+inicio/fin (mentres se enfoca nunha pista no Studio, Creator e
+  Track Tool): anuncia a primeira/última columna da pista.
+* Control+Alt+frecha arriba/abaixo (mentres se enfoque unha pista só en
+  Studio): Moverse á pista seguinte ou anterior e anuncia columnas
+  específicas.
 * Control+NVDA+1 a 0 (cun track enfocado en Studio, Creator e Track Tool):
   Anunciar contido da columna para unha columna especificada. Premer este
   atallo dúas veces amosará a información de columna nunha xanela de modo
   exploración.
-* Control+NVDA+- (guión, en Studio): Mostrar datos de todas as columnas
-  dunha pista nunha xanela de modo exploración.
+* Control+NVDA+- (guión, mentres se enfoca unha pista en Studio, Creator, e
+  Track Tool): amosar datos de todas as columnas dunha pista nunha xanela de
+  modo exploración.
 * Alt+NVDA+C mentres se enfoca unha pista (só Studio): anuncia os
   comentarios da pista se os hai.
 * Alt+NVDA+0 dende a ventá do Studio: Abre o diálogo de configuración do
@@ -324,9 +335,37 @@ realizar algunhas ordes do Studio dende a pantalla tactil. Primeiro usa un
 toque con tgres dedos para cambiar a modo SPL, logo usa as ordes tactiles
 listadas arriba para realizar ordes.
 
-## Version 20.01
+## Versión 20.02
 
-* NVDA 2019.3 or later is required due to extensive use of Python 3.
+* Soporte inicial para o Editor de Listas de Reprodución do StationPlaylist
+  Creator.
+* Engadidas as ordes Alt+NVDA+fila de números para anunciar varias
+  informacións de estado no Editor de Listas de Reprodución. Inclúen data e
+  hora para a lista (1), duración total da lista (2), cando a pista
+  seleccionada está programado para reproducirse (3), e rotación e categoría
+  (4).
+* ao enfocar unha pista en Creator e Track tool, agás no Editor de Listas de
+  Reprodución de Creator, ao premer Control+NVDA+Guión amosará todas as
+  columnas nunha ventá de modo exploración.
+* Se NVDA recoñece un elemento da lista de pistas con menos de 10 columnas,
+  NVDA xa non anunciará os encabezados de columnas que non existen se se
+  preme Control+NVDA+fila de números para columnas fóra de rango.
+* En Creator, NVDA xa non anunciará información de columna se se premen as
+  teclas Control+NVDA+fila de números enfocando lugares diferentes da lista
+  de pistas.
+* Cando unha pista se está reproducindo, NVDA xa non anunciará "Sen pista en
+  reprodución" ao abrir a información sobre a pista actual e seguinte a
+  través de SPL Assistant ou SPL controller.
+* Se está aberto un diálogo de opcións de alarma (intro, outro, micrófono),
+  NVDA xa non parecerá non facer nada ou non reproducirá tons de erro ao
+  tentar abrir unha segunda instancia de calquera diálogo de alarma.
+* ao tentar cambiar entre o perfil activo e un perfil instantáneo a través
+  de SPL Assitant (F12), NVDA presentará unha mensaxe se se intenta facer
+  cando a pantalla de opcións do complemento estea aberta.
+
+## Versión 20.01
+
+* Requírese NVDA 2019.3 ou posterior debido ao uso extensivo de Python 3.
 
 ## Versión 19.11.1/18.09.13-LTS
 

--- a/addon/doc/hr/readme.md
+++ b/addon/doc/hr/readme.md
@@ -18,8 +18,7 @@ izvornog koda.
 
 VAŽNE NAPOMENE:
 
-* This add-on requires NVDA 2019.3 or later and StationPlaylist suite 5.20
-  or later.
+* This add-on requires StationPlaylist suite 5.20 or later.
 * Korisnicima sustava Windows 8 ili novijeg, preporučamo deaktivirati modus
   stišavanja zvuka.
 * Starting from 2018, [changelogs for old add-on releases][5] will be found
@@ -46,12 +45,20 @@ Većina njih radi samo u programu Studio, ukoliko nešto drugo nije navedeno.
   sekunde do punog sata.
 * Alt+NVDA+1 (klizanje s dva prsta prema desno u dodirnom modusu SPL-a) u
   prozoru Studija: otvara dijaloški okvir s postavkama za kraj snimke.
+* Alt+NVDA+1 from Creator's Playlist Editor window: Announces scheduled time
+  for the loaded playlist.
 * Alt+NVDA+2 (klizanje s dva prsta prema lijevo u dodirnom modusu SPL-a) u
   prozoru Studija: otvara dijaloški okvir s postavkama alarma za uvodni dio
   pjesme.
+* Alt+NVDA+2 from Creator's Playlist Editor window: Announces total playlist
+  duration.
 * Alt+NVDA+3 u prozoru programa Studio: uključuje i isključuje istraživača
   džinglova za prikaz njima dodijeljenih naredbi.
+* Alt+NVDA+3 from Creator's Playlist Editor window: Announces when the
+  selected track is scheduled to play.
 * Alt+NVDA+4 u prozoru Studija: otvara dijaloški okvir za alarm mikrofona.
+* Alt+NVDA+4 from Creator's Playlist Editor window: Announces rotation and
+  category associated with the loaded playlist.
 * Control+NVDA+f u prozoru Studija: otvara dijaloški okvir za pronalaženje
   snimke na temelju izvođača ili pjesme. Pritisni NVDA+F3 za traženje prema
   naprijed ili NVDA+Shift+F3 za traženje prema natrag.
@@ -62,14 +69,16 @@ Većina njih radi samo u programu Studio, ukoliko nešto drugo nije navedeno.
 * Control+Alt+strelica lijevo ili desno (tijekom fokusiranja trake u
   programima Studio, Creator i Track Tool): najavi prethodni ili sljedeći
   stupac trake.
-* Control+Alt+strelica gore ili dolje (samo tijekom fokusiranja na snimku u
-  programu Studio): prijeđi na prethodnu ili sljedeću traku i najavi
-  određene stupce (nije dostupno u dodatku 15.x).
+* Control+Alt+Home/End (while focused on a track in Studio, Creator, and
+  Track Tool): Announce first/last track column.
+* Control+Alt+up/down arrow (while focused on a track in Studio only): Move
+  to previous or next track and announce specific columns.
 * Control+NVDA+1 do 0 (tijekom fokusiranja trake u programima Studio,
   Creator i Track Tool): najavi sadržaj stupca za određeni stupac. Pritisni
   naredbu dvaput za prikaz podataka stupca u prozoru modusa pregledavanja.
-* Control+NVDA+- (crtica u programu Studio): prikaži podatke svih stupaca u
-  snimci na prozoru modusa pregledavanja.
+* Control+NVDA+- (hyphen while focused on a track in Studio, Creator, and
+  Track Tool): display data for all columns in a track on a browse mode
+  window.
 * Alt+NVDA+C tijekom fokusiranja na snimku (samo Studio): najavljuje
   komentare snimke, ukoliko ih ima.
 * Alt+NVDA+0 u prozoru Studija: otvara dijaloški okvir za konfiguriranje
@@ -309,6 +318,32 @@ operacijskim sustavom Windows 8 ili novijim i ako imaš instaliran NVDA
 2012.3 ili noviji, možeš izvršiti neke Studio naredbe na ekranu osjetljivim
 na dodir. Za prebacivanje na modus SPL-a, dodirni ekran s tri prsta. Zatim
 koristi gore navedene dodirne naredbe za njihovo izvršavanje.
+
+## Version 20.02
+
+* Initial support for StationPlaylist Creator's Playlist Editor.
+* Added Alt+NVDA+number row commands to announce various status information
+  in Playlist Editor. These include date and time for the playlist (1),
+  total playlist duration (2), when the selected track is scheduled to play
+  (3), and rotation and category (4).
+* While focused on a track in Creator and Track Tool (except in Creator's
+  Playlist Editor), pressing Control+NVDA+Dash will display data for all
+  columns on a browse mode window.
+* If NVDA Recognizes a track list item with less than 10 columns, NVDA will
+  no longer announce headers for nonexistent columns if Control+NVDA+number
+  row for out of range column is pressed.
+* In creator, NVDA will no longer announce column information if
+  Control+NVDA+number row keys are pressed while focused on places other
+  than track list.
+* When a track is playing, NVDA will no longer announce "no track is
+  playing" if obtaining information about current and next tracks via SPL
+  Assistant or SPL Controller.
+* If an alarm options dialog (intro, outro, microphone) is open, NVDA will
+  no longer appear to do nothing or play error tone if attempting to open a
+  second instance of any alarm dialog.
+* When trying to switch between active profile and an instant profile via
+  SPL Assistant (F12), NVDA will present a message if attempting to do so
+  while add-on settings screen is open.
 
 ## Version 20.01
 

--- a/addon/doc/hr/readme.md
+++ b/addon/doc/hr/readme.md
@@ -344,6 +344,8 @@ koristi gore navedene dodirne naredbe za njihovo izvršavanje.
 * When trying to switch between active profile and an instant profile via
   SPL Assistant (F12), NVDA will present a message if attempting to do so
   while add-on settings screen is open.
+* In encoders, NVDA will no longer forget to apply no connection tone
+  setting for encoders when NVDA is restarted.
 
 ## Version 20.01
 

--- a/addon/doc/vi/readme.md
+++ b/addon/doc/vi/readme.md
@@ -17,7 +17,7 @@ xem tập tin buildInstructions.txt ở thư mục gốc trong mã nguồn của
 
 CÁC LƯU Ý QUAN TRỌNG:
 
-* Add-on này yêu cầu NVDA 2019.3 trở lên và bộ StationPlaylist 5.20 trở lên.
+* Add-on này yêu cầu bộ StationPlaylist 5.20 trở lên.
 * Nếu dùng Windows 8 trở lên, hãy tắt chế độ giảm âm thanh để có trải nghiệm
   tốt nhất.
 * Từ 2018, [bản ghi những thay đổi cho các bản phát hành cũ của add-on][5]
@@ -45,11 +45,19 @@ lập khác.
   lần sẽ thông báo số phút và giây đến đầu giờ.
 * Alt+NVDA+1 (vuốt hai ngón tay qua phải trong chế độ SPL) từ cửa sổ Studio:
   mở hộp thoại cài đặt kết thúc track.
+* Alt+NVDA+1 từ cửa sổ Creator's Playlist Editor: thông báo thời gian đã lên
+  lịch cho danh sách phát đã tải.
 * Alt+NVDA+2 (vuốt hai ngón qua trái trong chế độ SPL ) từ cửa sổ Studio: mở
   hộp thoại cài đặt báo nhạc hiệu.
+* Alt+NVDA+2 từ cửa sổ Playlist Editor của Creator: thông báo tổng thời gian
+  của danh sách phát.
 * Alt+NVDA+3 từ cửa sổ Studio: bật tắt cart explorer để tìm hiểu cách gán
   cart.
+* Alt+NVDA+3 từ cửa sổ  Playlist Editor của Creator: thông báo khi các track
+  được chọn đã lên lịch phát.
 * Alt+NVDA+4 từ cửa sổ Studio: mở hộp thoại báo hiệu microphone.
+* Alt+NVDA+4 từ cửa sổ Playlist Editor của Creator: thông báo vòng xoay và
+  phân loại đã kết hợp với danh sách phát đã tải.
 * Control+NVDA+f từ cửa sổ Studio: mở hộp thoại để tìm một track theo tên ca
   sĩ hay bài hát. Bấm NvDA+F3 để tìm tiếp hoặc NVDA+Shift+F3 để tìm lùi.
 * Alt+NVDA+R từ cửa sổ Studio: chuyển đến các cài đặt thông báo quét thư
@@ -57,14 +65,15 @@ lập khác.
 * Control+Shift+X từ cửa sổ Studio: đi qua các cài đặt hẹn giờ chữ nổi.
 * Control+Alt+mũi tên trái phải (khi đứng ở một track trong Studio, Creator,
   và Track Tool): thông báo các cột trước / sau của track.
+* Control+Alt+Home/End (khi đứng tại một track trong Studio, Creator và
+  Track Tool): thông báo cột đầu / cuối của track.
 * Control+Alt+mũi tên lên / xuống (chỉ khi đứng ở tại một track trong
-  Studio): chuyển đến track trước hoặc kế và thông báo các cột cụ thể (không
-  hỗ trợ cho các add-on phiên bản 15.x).
+  Studio): chuyển đến track trước hoặc kế và thông báo các cột cụ thể.
 * Control+NVDA+1 đến 0 (khi đứng ở tại một track trong Studio, Creator và
   Track Tool): thông báo nội dung cho một cột đã định. Bấm hai lần sẽ hiển
   thị thông tin trên cửa sổ duyệt tài liệu.
-* Control+NVDA+- (trừ trong Studio): hiển thị dữ liệu của tất cả các cột
-  trong một track trên một cửa sổ ở chế độ duyệt.
+* Control+NVDA+- (trừ trong Studio, Creator và Track Tool): hiển thị dữ liệu
+  của tất cả các cột trong một track trên một cửa sổ ở chế độ duyệt.
 * Alt+NVDA+C khi đứng tại một track (chỉ trong Studio): thông báo chú thích
   track nếu có.
 * Alt+NVDA+0 từ cửa sổ Studio: mở hộp thoại cấu hình add-on của Studio.
@@ -215,11 +224,11 @@ Các lệnh của bộ điều khiển SPL bao gồm:
 
 ## Các báo hiệu cho track
 
-Mặc định, NvDA sẽ phát tiếng beep nếu track còn five giây (ở cuối track)
-hoặc đầu track. Để thiết lập giá trị này hoặc bật / tắt chúng, bấm
-Alt+NVDA+1 hoặc Alt+NVDA+2 mở hộp thoại end of track và song ramp. Ngoài ra,
-dùng hộp thoại cài đặt add-on của Studio để thiết lập để nghe tiếng beep,
-một thông điệp hoặc chuông báo.
+Mặc định, NvDA sẽ phát tiếng beep nếu track còn 5 giây (ở cuối track) hoặc
+đầu track. Để thiết lập giá trị này hoặc bật / tắt chúng, bấm Alt+NVDA+1
+hoặc Alt+NVDA+2 mở hộp thoại end of track và song ramp. Ngoài ra, dùng hộp
+thoại cài đặt add-on của Studio để thiết lập để nghe tiếng beep, một thông
+điệp hoặc chuông báo.
 
 ## Báo hiệu microphone
 
@@ -289,6 +298,31 @@ Nếu dùng Studio trên một máy tính cảm ứng chạy Windows 8 trở lê
 NVDA 2012.3 trở lên, bạn có thể thực hiện vài lệnh của Studio từ mành hình
 cảm ứng. Trước tiên, dùng thao tác chạm ba ngón để chuyển sang chế độ SPL,
 và sử dụng các thao tác cảm ứng đã liệt kê ở trên để thực hiện các lệnh.
+
+## Phiên bản 20.02
+
+* Bắt đầu hỗ trợ cho StationPlaylist Creator's Playlist Editor.
+* Đã thêm các lệnh Alt+NVDA+phím số để thông báo nhiều thông tin trạng thái
+  trong Playlist Editor. Chúng bao gồm ngày và giờ cho danh sách phát (1),
+  tổng thời gian danh sách phát (2), khi track được chọn đã lên lịch phát
+  (3), vòng xoay và phân loại (4).
+* Khi đứng ở một track trong Creator và Track Tool (ngoại trừ trong
+  Creator's Playlist Editor), bấm Control+NVDA+trừ sẽ hiển thị dữ liệu của
+  tất cả các cột trên một cửa sổ chế độ duyệt.
+* Nếu NVDA nhận ra một thành phần trong danh sách track có ít hơn 10 cột,
+  NVDA sẽ không thông báo tiêu đề các cột không tồn tại khi bấm
+  Control+NVDA+các số ngoài vùng có tiêu đề cột.
+* Trong creator, NVDA sẽ không còn thông báo thông tin cột nếu bấm
+  Control+NVDA+các phím số khi không đứng tại danh sách track.
+* Khi một track đang phát, NVDA sẽ không còn thông báo "không có track nào
+  đang phát" nếu lấy thông tin về track hiện tại và kế tiếp thông qua SPL
+  Assistant hay SPL Controller.
+* Nếu một hộp thoại tùy chỉnh báo hiệu (nhạc hiệu, nhạc kết thúc,
+  microphone) được mở, NVDA sẽ không còn phát âm thanh báo lỗi hoặc không
+  làm gì nếu dự định mở một hộp thoại báo hiệu thứ hai.
+* Khi nỗ lực chuyển giữa hồ sơ đang hoạt động và một hồ sơ chuyển nhanh
+  thông qua SPL Assistant (F12), NVDA sẽ hiện một thông điệp nếu làm vậy khi
+  đang mở màn hình cài đặt add-on.
 
 ## Phiên bản 20.01
 

--- a/addon/doc/vi/readme.md
+++ b/addon/doc/vi/readme.md
@@ -323,6 +323,8 @@ và sử dụng các thao tác cảm ứng đã liệt kê ở trên để thự
 * Khi nỗ lực chuyển giữa hồ sơ đang hoạt động và một hồ sơ chuyển nhanh
   thông qua SPL Assistant (F12), NVDA sẽ hiện một thông điệp nếu làm vậy khi
   đang mở màn hình cài đặt add-on.
+* In encoders, NVDA will no longer forget to apply no connection tone
+  setting for encoders when NVDA is restarted.
 
 ## Phiên bản 20.01
 

--- a/addon/locale/de/LC_MESSAGES/nvda.po
+++ b/addon/locale/de/LC_MESSAGES/nvda.po
@@ -31,6 +31,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Veraltete Windows-Version"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Titel-Daten"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Zeigt Daten für alle Spalten des ausgewählten Titels an"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Mikrofon ist aktiv"
@@ -62,13 +70,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "Leer"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Titel-Daten"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,10 +112,6 @@ msgstr "{checkStatus}{header}: Keine"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "Zeigt Daten für alle Spalten des ausgewählten Titels an"
 
 msgid "Has comment"
 msgstr "Hat Kommentar"
@@ -420,11 +425,14 @@ msgid "Announces time including seconds."
 msgstr "Gibt die Zeit einschließlich Sekunden aus."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"Der Einstellungsdialog für die Erweiterung ist noch geöffnet. Bitte "
-"schließen Sie den Einstellungsdialog."
+"der Dialog für die Einstellungen zur Studio-Erweiterung oder der Metadaten-"
+"Streaming-Dialog ist geöffnet. Bitte schließen Sie den geöffneten Dialog "
+"zuerst."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -725,7 +733,14 @@ msgid "Playlist modification not available"
 msgstr "Änderung der Wiedergabeliste nicht möglich"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Es wird momentan keinen Titel wiedergegeben."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr ""
 "Momentan wird kein Titel oder kein weiterer geplanter Titel  wiedergegeben."
 
@@ -738,10 +753,10 @@ msgid "Announces title of the next track if any"
 msgstr "Kündigt jeden Titel an."
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
+#, fuzzy
+msgid "Cannot locate current track information"
 msgstr ""
-"Die Informationen über den aktuellen Titel konnten nicht abgerufen werden. "
-"Möglicherweise wird keiner abgespielt."
+"Es konnten keine Informationen über den aktuellen Titel abgerufen werden."
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -815,6 +830,12 @@ msgid ""
 "artists"
 msgstr ""
 "Zeigt Playlist-Statistiken, wie z. B. die Anzahl der Titel und Top künstler."
+
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"Der Einstellungsdialog für die Erweiterung ist geöffnet; es kann nicht "
+"zwischen Profilen umgeschaltet werden."
 
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
@@ -890,12 +911,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Zurücksetzen der SPL-Erweiterung"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"Der Einstellungsdialog für die Erweiterung ist geöffnet; es kann nicht "
-"zwischen Profilen umgeschaltet werden."
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1996,6 +2011,12 @@ msgstr "Zuhörer: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Es wird momentan keinen Titel wiedergegeben."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr ""
+"Statusinformationen zum Metadaten-Streaming können nicht abgerufen werden"
+
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"
 msgstr "Meldet den Status des Stream-Encoders aus anderen Programmen heraus."
@@ -2011,188 +2032,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Hilfe zur SPL-Steuerung"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "Keine Encoder gefunden."
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr "Es kann nur ein Encoder-Typ gleichzeitig aktiv sein."
-
-#. Translators: presented when at least one encoder is connected.
-#, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Verbundene Encoder: {encodersConnected}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "Keine Encoder verbunden."
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Encoder-Einstellungen für {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "Stream-&Bezeichnung"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "&Bei Verbindungsaufbau zu Studio wechseln"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Ersten Titel nach dem Verbindungsaufbau abspielen"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Aktiviert Hintergrundüberwachung und -Verbindungsaufbau"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Spielt Status der Verbindung ab &Piepton während Verbindungsaufbau"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Bei Verbindungsaufbau zu Studio wechseln"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Bei Verbindungsaufbau nicht zu Studio wechseln"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Legt fest, ob NVDA in das Studio-Hauptfenster wechseln soll, sobald die "
-"Verbindung zu einem Streaming-Server hergestellt wurde."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Ersten Titel nach dem Verbindungsaufbau abspielen"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Ersten Titel nach dem Verbindungsaufbau nicht abspielen"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"legt fest, ob Studio nach dem Verbindungsaufbau den ersten Titel aus der "
-"titelliste abspielen soll."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Überwachen der Encoder {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Encoder {encoderNumber} wird nicht überwacht"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Encoderüberwachung abgebrochen"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr ""
-"legt fest, ob NVDA den ausgewählten Encoder im Hintergrund überwachen soll."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Stream-Bezeichnung  für {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Geben Sie die Bezeichnung für diesen Stream ein:"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr ""
-"Öffnet einen Dialog, in dem Sie den ausgewählten Encoder beschriften können."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr ""
-"Einstellungen zum Löschen der Streambezeichnungen und Zurücksetzen anderer "
-"Einstellungen"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "Geben Sie die Position des Encoddrs ein, den Sie löschen möchten"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Öffnet einen Dialog, mit dem Beschriftungen und Einstellungen gelöschter "
-"Encoder entfernt werden können."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Ein weiteres Dialog für Encoder-Einstellungen ist geöffnet."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Zeigt das Encoder-Konfiguationsdialog, wo beispielsweise Streambezeichnungen "
-"eingestellt werden können."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Bei ein Mal drücken der Tastenkombination wird die aktuelle Uhrzeit "
-"einschließlich Sekunden und bei zwei Mal drücken das aktuelle Datum angesagt."
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Position: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Bezeichnung: {label}"
-
-msgid "No stream label"
-msgstr "Keine Stream-Bezeichnung"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Verbinden..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Verbindung trennen..."
-
-msgid "Connects to a streaming server."
-msgstr "Stellt die Verbindung mit einem Streaming-Server her."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Encoder-Einstellungen: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Übertragungsgeschwindigkeit: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2202,3 +2041,157 @@ msgstr ""
 "Verbessert die Unterstützung für Station Playlist Studio.\n"
 "Des weiteren fügt es Tastenkombinationen für das Studio aus beliebigen "
 "Programmen hinzu."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "Der Einstellungsdialog für die Erweiterung ist noch geöffnet. Bitte "
+#~ "schließen Sie den Einstellungsdialog."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Die Informationen über den aktuellen Titel konnten nicht abgerufen "
+#~ "werden. Möglicherweise wird keiner abgespielt."
+
+#~ msgid "No encoders found"
+#~ msgstr "Keine Encoder gefunden."
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr "Es kann nur ein Encoder-Typ gleichzeitig aktiv sein."
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Verbundene Encoder: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Keine Encoder verbunden."
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Encoder-Einstellungen für {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "Stream-&Bezeichnung"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&Bei Verbindungsaufbau zu Studio wechseln"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Ersten Titel nach dem Verbindungsaufbau abspielen"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Aktiviert Hintergrundüberwachung und -Verbindungsaufbau"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Spielt Status der Verbindung ab &Piepton während Verbindungsaufbau"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Bei Verbindungsaufbau zu Studio wechseln"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Bei Verbindungsaufbau nicht zu Studio wechseln"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Legt fest, ob NVDA in das Studio-Hauptfenster wechseln soll, sobald die "
+#~ "Verbindung zu einem Streaming-Server hergestellt wurde."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Ersten Titel nach dem Verbindungsaufbau abspielen"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Ersten Titel nach dem Verbindungsaufbau nicht abspielen"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "legt fest, ob Studio nach dem Verbindungsaufbau den ersten Titel aus der "
+#~ "titelliste abspielen soll."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Überwachen der Encoder {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Encoder {encoderNumber} wird nicht überwacht"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Encoderüberwachung abgebrochen"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr ""
+#~ "legt fest, ob NVDA den ausgewählten Encoder im Hintergrund überwachen "
+#~ "soll."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Stream-Bezeichnung  für {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Geben Sie die Bezeichnung für diesen Stream ein:"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr ""
+#~ "Öffnet einen Dialog, in dem Sie den ausgewählten Encoder beschriften "
+#~ "können."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr ""
+#~ "Einstellungen zum Löschen der Streambezeichnungen und Zurücksetzen "
+#~ "anderer Einstellungen"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "Geben Sie die Position des Encoddrs ein, den Sie löschen möchten"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Öffnet einen Dialog, mit dem Beschriftungen und Einstellungen gelöschter "
+#~ "Encoder entfernt werden können."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Ein weiteres Dialog für Encoder-Einstellungen ist geöffnet."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Zeigt das Encoder-Konfiguationsdialog, wo beispielsweise "
+#~ "Streambezeichnungen eingestellt werden können."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Bei ein Mal drücken der Tastenkombination wird die aktuelle Uhrzeit "
+#~ "einschließlich Sekunden und bei zwei Mal drücken das aktuelle Datum "
+#~ "angesagt."
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Position: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Bezeichnung: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Keine Stream-Bezeichnung"
+
+#~ msgid "Connecting..."
+#~ msgstr "Verbinden..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Verbindung trennen..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Stellt die Verbindung mit einem Streaming-Server her."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Encoder-Einstellungen: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Übertragungsgeschwindigkeit: {transferRate}"

--- a/addon/locale/de_CH/LC_MESSAGES/nvda.po
+++ b/addon/locale/de_CH/LC_MESSAGES/nvda.po
@@ -31,6 +31,15 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Veraltete Windowsversion"
 
+#. Translators: Title of the column data window.
+#, fuzzy
+msgid "Track data"
+msgstr "Vorspiel von Titeln"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr ""
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Mikrofon ist aktiv"
@@ -61,14 +70,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "Station Playlist Studio (SPL)"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr ""
-
-#. Translators: Title of the column data window.
-#, fuzzy
-msgid "Track data"
-msgstr "Vorspiel von Titeln"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,10 +112,6 @@ msgstr "{checkStatus}{header}: Leer"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr ""
 
 msgid "Has comment"
 msgstr "Hat Kommentar"
@@ -418,11 +423,14 @@ msgid "Announces time including seconds."
 msgstr "Gibt die Zeit einschliesslich Sekunden aus."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"Der Einstellungsdialog für die Erweiterung ist noch geöffnet. Bitte "
-"schliessen Sie den Einstellungsdialog."
+"der Dialog für die Einstellungen zur Studio-Erweiterung oder der Metadaten-"
+"Streaming-Dialog ist geöffnet. Bitte schliessen Sie den geöffneten Dialog "
+"zuerst."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -723,7 +731,14 @@ msgid "Playlist modification not available"
 msgstr "Änderung der Wiedergabeliste nicht möglich"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Es wird momentan keinen Titel wiedergegeben."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr ""
 "Momentan wird kein Titel oder kein weiterer geplanter Titel  wiedergegeben."
 
@@ -736,10 +751,10 @@ msgid "Announces title of the next track if any"
 msgstr "Sagt jeden Songtitel an."
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
+#, fuzzy
+msgid "Cannot locate current track information"
 msgstr ""
-"Die Informationen über den aktuellen Titel konnten nicht abgerufen werden. "
-"Möglicherweise wird kein titel abgespielt."
+"Es konnten keine informationen über den aktuellen Titel abgerufen werden."
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -814,6 +829,12 @@ msgid ""
 msgstr ""
 "Zeigt Playlist-Statistiken, wie z.B. die Anzahl der Titel und Top künstler."
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"Der Einstellungsdialog für die Erweiterung ist geöffnet; es kann nicht "
+"zwischen Profilen umgeschaltet werden."
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "Keine Titel gefunden, die Markierung konnte nicht gesetzt werden"
@@ -884,12 +905,6 @@ msgstr ""
 #, fuzzy
 msgid "SPL Studio add-on reset"
 msgstr "Einstellungen zur Studio-Erweiterung"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"Der Einstellungsdialog für die Erweiterung ist geöffnet; es kann nicht "
-"zwischen Profilen umgeschaltet werden."
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -2001,6 +2016,12 @@ msgstr "Anzahl der Zuhörer: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Es wird momentan keinen Titel wiedergegeben."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr ""
+"Statusinformationen zum Metadaten-Streaming können nicht abgerufen werden"
+
 #. Translators: Input help message for a SPL Controller command.
 #, fuzzy
 msgid "Announces stream encoder status from other programs"
@@ -2019,191 +2040,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Hilfe zum SPL-Controller"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-#, fuzzy
-msgid "No encoders found"
-msgstr "Keine Markierung gefunden"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr ""
-
-#. Translators: presented when at least one encoder is connected.
-#, fuzzy, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Überwachen der Encoder {encoderNumber}"
-
-#. Translators: presented when no encoders are connected.
-#, fuzzy
-msgid "No encoders connected"
-msgstr "Es werden keine Encoder überwacht"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Encoder-Einstellungen für {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "Stream-&Bezeichnung"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "&Bei Verbindungsaufbau zu Studio wechseln"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Ersten Titel nach dem Verbindungsaufbau abspielen"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Aktiviert Hintergrundüberwachung und -Verbindungsaufbau"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Spielt Status der Verbindung ab &Piepton während Verbindungsaufbau"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Bei Verbindungsaufbau zu Studio wechseln"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Bei Verbindungsaufbau nicht zu Studio wechseln"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Legt fest, ob NVDA in das Studio-Hauptfenster wechseln soll, sobald die "
-"Verbindung zu einem Streaming-Server hergestellt wurde."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Ersten Titel nach dem Verbindungsaufbau abspielen"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Ersten Titel nach dem Verbindungsaufbau nicht abspielen"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"legt fest, ob Studio nach dem Verbindungsaufbau den ersten Titel aus der "
-"titelliste abspielen soll."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Überwachen der Encoder {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Encoder {encoderNumber} wird nicht überwacht"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Encoderüberwachung abgebrochen"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr ""
-"legt fest, ob NVDA den ausgewählten Encoder im Hintergrund überwachen soll."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Stream-Bezeichnung  für {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Geben Sie die Bezeichnung für diesen Stream ein:"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr ""
-"Öffnet einen Dialog, in dem Sie den ausgewählten Encoder beschriften können."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr ""
-"Einstellungen zum Löschen der Streambezeichnungen und Zurücksetzen anderer "
-"Einstellungen"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "Geben Sie die Position des Encoddrs ein, den Sie löschen möchten"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Öffnet einen Dialog, mit dem Beschriftungen und Einstellungen gelöschter "
-"Encoder entfernt werden können."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Ein weiteres Dialog für Encoder-Einstellungen ist geöffnet."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Zeigt das Encoder-Konfiguationsdialog, wo beispielsweise Streambezeichnungen "
-"eingestellt werden können."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Bei ein Mal drücken der Tastenkombination wird die aktuelle Uhrzeit "
-"einschliesslich Sekunden und bei zwei Mal drücken das aktuelle Datum "
-"angesagt."
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Position: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Bezeichnung: {label}"
-
-msgid "No stream label"
-msgstr "Keine Stream-Bezeichnung"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Verbinden..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Verbindung trennen..."
-
-msgid "Connects to a streaming server."
-msgstr "Stellt die Verbindung mit einem Streaming-Server her."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Encoder-Einstellungen: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Übertragungsgeschwindigkeit: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2213,3 +2049,157 @@ msgstr ""
 "Verbessert die Unterstützung für Station Playlist Studio.\n"
 "Des weiteren fügt es Tastenkombinationen für das Studio aus beliebigen "
 "Programmen hinzu."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "Der Einstellungsdialog für die Erweiterung ist noch geöffnet. Bitte "
+#~ "schliessen Sie den Einstellungsdialog."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Die Informationen über den aktuellen Titel konnten nicht abgerufen "
+#~ "werden. Möglicherweise wird kein titel abgespielt."
+
+#, fuzzy
+#~ msgid "No encoders found"
+#~ msgstr "Keine Markierung gefunden"
+
+#, fuzzy
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Überwachen der Encoder {encoderNumber}"
+
+#, fuzzy
+#~ msgid "No encoders connected"
+#~ msgstr "Es werden keine Encoder überwacht"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Encoder-Einstellungen für {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "Stream-&Bezeichnung"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&Bei Verbindungsaufbau zu Studio wechseln"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Ersten Titel nach dem Verbindungsaufbau abspielen"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Aktiviert Hintergrundüberwachung und -Verbindungsaufbau"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Spielt Status der Verbindung ab &Piepton während Verbindungsaufbau"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Bei Verbindungsaufbau zu Studio wechseln"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Bei Verbindungsaufbau nicht zu Studio wechseln"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Legt fest, ob NVDA in das Studio-Hauptfenster wechseln soll, sobald die "
+#~ "Verbindung zu einem Streaming-Server hergestellt wurde."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Ersten Titel nach dem Verbindungsaufbau abspielen"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Ersten Titel nach dem Verbindungsaufbau nicht abspielen"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "legt fest, ob Studio nach dem Verbindungsaufbau den ersten Titel aus der "
+#~ "titelliste abspielen soll."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Überwachen der Encoder {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Encoder {encoderNumber} wird nicht überwacht"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Encoderüberwachung abgebrochen"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr ""
+#~ "legt fest, ob NVDA den ausgewählten Encoder im Hintergrund überwachen "
+#~ "soll."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Stream-Bezeichnung  für {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Geben Sie die Bezeichnung für diesen Stream ein:"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr ""
+#~ "Öffnet einen Dialog, in dem Sie den ausgewählten Encoder beschriften "
+#~ "können."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr ""
+#~ "Einstellungen zum Löschen der Streambezeichnungen und Zurücksetzen "
+#~ "anderer Einstellungen"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "Geben Sie die Position des Encoddrs ein, den Sie löschen möchten"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Öffnet einen Dialog, mit dem Beschriftungen und Einstellungen gelöschter "
+#~ "Encoder entfernt werden können."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Ein weiteres Dialog für Encoder-Einstellungen ist geöffnet."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Zeigt das Encoder-Konfiguationsdialog, wo beispielsweise "
+#~ "Streambezeichnungen eingestellt werden können."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Bei ein Mal drücken der Tastenkombination wird die aktuelle Uhrzeit "
+#~ "einschliesslich Sekunden und bei zwei Mal drücken das aktuelle Datum "
+#~ "angesagt."
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Position: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Bezeichnung: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Keine Stream-Bezeichnung"
+
+#~ msgid "Connecting..."
+#~ msgstr "Verbinden..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Verbindung trennen..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Stellt die Verbindung mit einem Streaming-Server her."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Encoder-Einstellungen: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Übertragungsgeschwindigkeit: {transferRate}"

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: StationPlaylist 17.04\n"
 "Report-Msgid-Bugs-To: nvda-translations@freelists.org\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2019-11-21 16:17-0800\n"
+"PO-Revision-Date: 2020-01-26 18:38+0100\n"
 "Last-Translator: José Manuel Delicado <jmdaweb@hotmail.com>\n"
 "Language-Team: Add-ons translation team <LL@li.org>\n"
 "Language: es_ES\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 2.2.4\n"
 "X-Poedit-SourceCharset: UTF-8\n"
 
 #. Translators: Presented when attempting to install StationPlaylist add-on on unsupported Windows releases.
@@ -74,7 +74,7 @@ msgstr "StationPlaylist"
 #. Translators: Presented when column is out of range.
 #, python-brace-format
 msgid "Column {columnPosition} not found"
-msgstr ""
+msgstr "Columna {columnPosition} no encontrada"
 
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
@@ -425,13 +425,12 @@ msgid "Announces time including seconds."
 msgstr "Anuncia el tiempo incluyendo segundos."
 
 #. Translators: Presented when the add-on config dialog is opened.
-#, fuzzy
 msgid ""
 "The add-on settings dialog or another alarm dialog is opened. Please close "
 "the opened dialog first."
 msgstr ""
-"Los diálogos de opciones del complemento o metadatos del streaming están "
-"abiertos. Por favor ciérralos antes."
+"El diálogo de opciones del complemento o un diálogo de alarma está abierto. "
+"Por favor, ciérralo primero."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -726,14 +725,12 @@ msgstr "Modificación de lista de reproducción no disponible"
 
 #. Translators: Presented when there is no information for the next track.
 #. Translators: Presented when there is no information for the current track.
-#, fuzzy
 msgid "No track is playing"
-msgstr "No hay pista en reproducción."
+msgstr "No hay pista en reproducción"
 
 #. Translators: Presented when there is no information for the next track.
-#, fuzzy
 msgid "No next track scheduled"
-msgstr "No hay siguiente pista programada o no hay pista en reproducción"
+msgstr "No hay siguiente pista programada"
 
 #. Translators: Presented when next track information is unavailable.
 msgid "Cannot find next track information"
@@ -744,9 +741,8 @@ msgid "Announces title of the next track if any"
 msgstr "Anuncia el título de la siguiente pista si la hay"
 
 #. Translators: Presented when there is no information for the current track.
-#, fuzzy
 msgid "Cannot locate current track information"
-msgstr "No se pudo encontrar información de la pista"
+msgstr "No se pudo encontrar información de la pista actual"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -1994,9 +1990,8 @@ msgid "There is no track playing."
 msgstr "No hay pista en reproducción."
 
 #. Translators: presented if encoder connection status cannot be obtained.
-#, fuzzy
 msgid "Cannot obtain encoder connection status"
-msgstr "No se pudo obtener la información sobre la transmisión de metadatos"
+msgstr "No se puede obtener el estado de conexión del codificador"
 
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"

--- a/addon/locale/es/LC_MESSAGES/nvda.po
+++ b/addon/locale/es/LC_MESSAGES/nvda.po
@@ -31,6 +31,15 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Versión antigua de Windows"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Datos de pista"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr ""
+"Presenta datos para todas las columnas en la pista actualmente seleccionada"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Micrófono activo"
@@ -62,13 +71,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "en blanco"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Datos de pista"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,11 +113,6 @@ msgstr "{checkStatus}{header}: en branco"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr ""
-"Presenta datos para todas las columnas en la pista actualmente seleccionada"
 
 msgid "Has comment"
 msgstr "Tiene comentario"
@@ -420,11 +425,13 @@ msgid "Announces time including seconds."
 msgstr "Anuncia el tiempo incluyendo segundos."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"El diálogo de opciones del complemento está abierto. Por favor ciérralo "
-"antes."
+"Los diálogos de opciones del complemento o metadatos del streaming están "
+"abiertos. Por favor ciérralos antes."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -718,7 +725,14 @@ msgid "Playlist modification not available"
 msgstr "Modificación de lista de reproducción no disponible"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "No hay pista en reproducción."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "No hay siguiente pista programada o no hay pista en reproducción"
 
 #. Translators: Presented when next track information is unavailable.
@@ -730,10 +744,9 @@ msgid "Announces title of the next track if any"
 msgstr "Anuncia el título de la siguiente pista si la hay"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"No se pudo localizar la información de pista actual o no hay pista en "
-"reproducción"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "No se pudo encontrar información de la pista"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -810,6 +823,12 @@ msgstr ""
 "Presenta información de las instantáneas de listas de reproducción tal como "
 "número de pistas y artistas principales"
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"El diálogo de opciones del complemento está abierto. no se puede cambiar de "
+"perfil"
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "No se encontraron pistas, no se pudo ajustar el marcador"
@@ -884,12 +903,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Restablecimiento del complemento SPL Studio"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"El diálogo de opciones del complemento está abierto. no se puede cambiar de "
-"perfil"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1980,6 +1993,11 @@ msgstr "Recuento de oyentes: {listenerCount}"
 msgid "There is no track playing."
 msgstr "No hay pista en reproducción."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "No se pudo obtener la información sobre la transmisión de metadatos"
+
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"
 msgstr "Anuncia el estado del codificador de flujo desde otros programas"
@@ -1995,186 +2013,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Ayuda del SPL Controller"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "No se encontraron codificadores"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr "Sólo puede haber un codificador de cada tipo activado a la vez"
-
-#. Translators: presented when at least one encoder is connected.
-#, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Codificadores conectados: {encodersConnected}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "No hay codificadores conectados"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Opciones de codificador para {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "&Etiqueta de cadena"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "En&focar a Studio cuando esté conectado"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Reproducir primera pista cuando esté conectado"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Habilitar &monitorización de conexión en segundo plano"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Reproduce el &pitido de estado de la conexión mientras se conecta"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Cambiar a Studio después de conectarse"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "No cambiar a Studio después de conectarse"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Conmuta si NVDA cambiará a Studio cuando esté conectado a un servidor de "
-"streaming."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Reproducir primera pista después de conectar"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "No reproducir primera pista después de conectar"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Conmuta si Studio reproducirá o no la primera  canción cuando se conecte a "
-"un servidor de streaming."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Monitorizando codificador {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "El codificador {encoderNumber} no se monitorizará"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Monitorización de codificador cancelada"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr ""
-"Conmuta si NVDA monitorizará el codificador seleccionado en segundo plano."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Etiquetador de Stream para {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Introduce la etiqueta para este stream"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Abre un diálogo para etiquetar el codificador seleccionado."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Eliminador de etiqueta de cadena y opciones"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr ""
-"Introduce la posición del codificador que deseas eliminar o se eliminará"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Abre un diálogo para borrar etiquetas de cadena y opciones de un codificador "
-"que fue eleminado."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Está abierto otro diálogo de opciones del codificador."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Muestra el diálogo configuración de codificador para configurar varias "
-"opciones del codificador tales como la etiqueta de la cadena."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Si se pulsó una vez, anuncia la hora actual incluyendo segundos. Si se pulsó "
-"dos veces, anuncia la fecha actual"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Posición: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Etiqueta: {label}"
-
-msgid "No stream label"
-msgstr "No hay etiqueta de cadena"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Conectando..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Desconectando..."
-
-msgid "Connects to a streaming server."
-msgstr "Conecta a un servidor de streaming."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Opciones de Codificador: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Velocidad de Transferencia: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2183,3 +2021,152 @@ msgid ""
 msgstr ""
 "Mejora el soporte para Station Playlist Studio.\n"
 "Además, agrega comandos globales para el estudio desde cualquier parte."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "El diálogo de opciones del complemento está abierto. Por favor ciérralo "
+#~ "antes."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "No se pudo localizar la información de pista actual o no hay pista en "
+#~ "reproducción"
+
+#~ msgid "No encoders found"
+#~ msgstr "No se encontraron codificadores"
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr "Sólo puede haber un codificador de cada tipo activado a la vez"
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Codificadores conectados: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "No hay codificadores conectados"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Opciones de codificador para {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Etiqueta de cadena"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "En&focar a Studio cuando esté conectado"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Reproducir primera pista cuando esté conectado"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Habilitar &monitorización de conexión en segundo plano"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Reproduce el &pitido de estado de la conexión mientras se conecta"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Cambiar a Studio después de conectarse"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "No cambiar a Studio después de conectarse"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Conmuta si NVDA cambiará a Studio cuando esté conectado a un servidor de "
+#~ "streaming."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Reproducir primera pista después de conectar"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "No reproducir primera pista después de conectar"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Conmuta si Studio reproducirá o no la primera  canción cuando se conecte "
+#~ "a un servidor de streaming."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Monitorizando codificador {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "El codificador {encoderNumber} no se monitorizará"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Monitorización de codificador cancelada"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr ""
+#~ "Conmuta si NVDA monitorizará el codificador seleccionado en segundo plano."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Etiquetador de Stream para {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Introduce la etiqueta para este stream"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Abre un diálogo para etiquetar el codificador seleccionado."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Eliminador de etiqueta de cadena y opciones"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr ""
+#~ "Introduce la posición del codificador que deseas eliminar o se eliminará"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Abre un diálogo para borrar etiquetas de cadena y opciones de un "
+#~ "codificador que fue eleminado."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Está abierto otro diálogo de opciones del codificador."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Muestra el diálogo configuración de codificador para configurar varias "
+#~ "opciones del codificador tales como la etiqueta de la cadena."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Si se pulsó una vez, anuncia la hora actual incluyendo segundos. Si se "
+#~ "pulsó dos veces, anuncia la fecha actual"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Posición: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Etiqueta: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "No hay etiqueta de cadena"
+
+#~ msgid "Connecting..."
+#~ msgstr "Conectando..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Desconectando..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Conecta a un servidor de streaming."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Opciones de Codificador: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Velocidad de Transferencia: {transferRate}"

--- a/addon/locale/fr/LC_MESSAGES/nvda.po
+++ b/addon/locale/fr/LC_MESSAGES/nvda.po
@@ -30,6 +30,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Ancienne version de Windows"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Données de piste"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Présente des données pour toutes les colonnes de la piste sélectionnée"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Microphone actif"
@@ -62,13 +70,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist Studio"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "vide"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Données de piste"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,10 +112,6 @@ msgstr "{checkStatus}{header} : vide"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header} : ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "Présente des données pour toutes les colonnes de la piste sélectionnée"
 
 msgid "Has comment"
 msgstr "A un commentaire"
@@ -419,11 +424,13 @@ msgid "Announces time including seconds."
 msgstr "Annonce l'heure avec les secondes."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"Le dialogue de paramètres de l'extension est ouvert. Veuillez d'abord le "
-"fermer."
+"Le dialogue de paramètres ou le dialogue de métadonnées en streaming de "
+"l'extension est ouvert. Veuillez d'abord le fermer."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -725,7 +732,14 @@ msgid "Playlist modification not available"
 msgstr "Modification playlist non disponible"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Il n'y a aucune piste en cours de lecture."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "Aucune piste planifiée ou aucune piste n'est en cours de lecture"
 
 #. Translators: Presented when next track information is unavailable.
@@ -737,10 +751,9 @@ msgid "Announces title of the next track if any"
 msgstr "Annonce le titre de la piste suivante s'il y a lieu"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Impossible de trouver les informations de piste actuelle  ou aucune piste "
-"n'est en cours de lecture"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Impossible de trouver les informations de la piste actuelle"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -817,6 +830,12 @@ msgstr ""
 "Présente l'information sur les instantanés de playlist, comme le nombre de "
 "morceaux et les meilleurs artistes"
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"Le dialogue de paramètres de l'extension est ouvert, Impossible de basculer "
+"vers les profils"
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "Aucune piste trouvée, impossible de définir un marqueur de position"
@@ -892,12 +911,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Réinitialiser l'extension SPL Studio"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"Le dialogue de paramètres de l'extension est ouvert, Impossible de basculer "
-"vers les profils"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1993,6 +2006,13 @@ msgstr "Nombre d'auditeurs : {listenerCount}"
 msgid "There is no track playing."
 msgstr "Il n'y a aucune piste en cours de lecture."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr ""
+"Impossible d'obtenir le statut des informations pour les métadonnées en "
+"streaming"
+
 #. Translators: Input help message for a SPL Controller command.
 #, fuzzy
 msgid "Announces stream encoder status from other programs"
@@ -2011,188 +2031,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Aide du Contrôleur SPL"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-#, fuzzy
-msgid "No encoders found"
-msgstr "Aucun marqueur de position trouvé"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr ""
-
-#. Translators: presented when at least one encoder is connected.
-#, fuzzy, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Contrôle en cours d'encodeur {encoderNumber}"
-
-#. Translators: presented when no encoders are connected.
-#, fuzzy
-msgid "No encoders connected"
-msgstr "Pas d'encodeurs monitorés actuellement"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Paramètres de l'encodeur pour {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "Étiquette de f&lux"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "Mettez le &focus vers Studio lorsqu'il est connecté"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Lire la première piste lorsqu'il est connecté"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Activer la &surveillance de la connexion en arrière-plan"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Lire le statut de la connexion en &bip lors de la connexion"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber} : {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Basculer vers Studio après la connexion"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Ne pas basculer vers Studio après la connexion"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Détermine si NVDA bascule vers Studio lorsqu'il est connecté à un serveur de "
-"flux."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Lire la première piste après la connexion"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Ne pas lire la première piste après la connexion"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Détermine si Studio lit la première piste lorsqu'il est connecté à un "
-"serveur de flux."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Contrôle en cours d'encodeur {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Encodeur {encoderNumber} ne sera pas contrôlé"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Contrôle d'Encodeur annulé"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "Détermine si NVDA surveille l'encodeur sélectionné en arrière-plan."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Étiqueteuse de flux pour {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Entrez l'étiquette pour ce flux"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Ouvre un dialogue pour étiqueter l'encodeur sélectionné."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Effaceur d'étiquette de flux et de paramètres"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr ""
-"Entrez la position de l'encodeur que vous souhaitez supprimer ou que vous "
-"supprimerez"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Ouvre un dialogue pour effacer les étiquettes de flux  et les paramètres "
-"d'un encodeur qui a été supprimé."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Un autre dialogue de paramètres de l'encodeur est ouvert."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Affiche le dialogue de configuration de l'encodeur pour configurer "
-"différents paramètres de l’encodeur comme l'étiquette de flux."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Un appui annonce l'heure en cours, y compris les secondes. Deux appuis "
-"annoncent la date courante"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Position : {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Étiquette : {label}"
-
-msgid "No stream label"
-msgstr "Pas d'étiquette de flux"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Connexion en cours..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Déconnexion en cours..."
-
-msgid "Connects to a streaming server."
-msgstr "Se connecter à un serveur de flux."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Paramètres de l'Encodeur : {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Taux de Transfert : {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2201,3 +2039,152 @@ msgid ""
 msgstr ""
 "Améliore la prise en charge de StationPlaylist Studio.\n"
 "En outre, ajoute des commandes globales pour studio où que vous soyez."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "Le dialogue de paramètres de l'extension est ouvert. Veuillez d'abord le "
+#~ "fermer."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Impossible de trouver les informations de piste actuelle  ou aucune piste "
+#~ "n'est en cours de lecture"
+
+#, fuzzy
+#~ msgid "No encoders found"
+#~ msgstr "Aucun marqueur de position trouvé"
+
+#, fuzzy
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Contrôle en cours d'encodeur {encoderNumber}"
+
+#, fuzzy
+#~ msgid "No encoders connected"
+#~ msgstr "Pas d'encodeurs monitorés actuellement"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Paramètres de l'encodeur pour {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "Étiquette de f&lux"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "Mettez le &focus vers Studio lorsqu'il est connecté"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Lire la première piste lorsqu'il est connecté"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Activer la &surveillance de la connexion en arrière-plan"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Lire le statut de la connexion en &bip lors de la connexion"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber} : {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Basculer vers Studio après la connexion"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Ne pas basculer vers Studio après la connexion"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Détermine si NVDA bascule vers Studio lorsqu'il est connecté à un serveur "
+#~ "de flux."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Lire la première piste après la connexion"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Ne pas lire la première piste après la connexion"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Détermine si Studio lit la première piste lorsqu'il est connecté à un "
+#~ "serveur de flux."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Contrôle en cours d'encodeur {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Encodeur {encoderNumber} ne sera pas contrôlé"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Contrôle d'Encodeur annulé"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Détermine si NVDA surveille l'encodeur sélectionné en arrière-plan."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Étiqueteuse de flux pour {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Entrez l'étiquette pour ce flux"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Ouvre un dialogue pour étiqueter l'encodeur sélectionné."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Effaceur d'étiquette de flux et de paramètres"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr ""
+#~ "Entrez la position de l'encodeur que vous souhaitez supprimer ou que vous "
+#~ "supprimerez"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Ouvre un dialogue pour effacer les étiquettes de flux  et les paramètres "
+#~ "d'un encodeur qui a été supprimé."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Un autre dialogue de paramètres de l'encodeur est ouvert."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Affiche le dialogue de configuration de l'encodeur pour configurer "
+#~ "différents paramètres de l’encodeur comme l'étiquette de flux."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Un appui annonce l'heure en cours, y compris les secondes. Deux appuis "
+#~ "annoncent la date courante"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Position : {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Étiquette : {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Pas d'étiquette de flux"
+
+#~ msgid "Connecting..."
+#~ msgstr "Connexion en cours..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Déconnexion en cours..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Se connecter à un serveur de flux."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Paramètres de l'Encodeur : {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Taux de Transfert : {transferRate}"

--- a/addon/locale/gl/LC_MESSAGES/nvda.po
+++ b/addon/locale/gl/LC_MESSAGES/nvda.po
@@ -31,6 +31,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Versión vella de Windows"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Datos da pista"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Presenta datos para todas as columnas na pista actualmente selecionada"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Micrófono activo"
@@ -62,13 +70,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "en branco"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Datos da pista"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,10 +112,6 @@ msgstr "{checkStatus}{header}: en blanco"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "Presenta datos para todas as columnas na pista actualmente selecionada"
 
 msgid "Has comment"
 msgstr "Ten comentario"
@@ -416,10 +421,13 @@ msgid "Announces time including seconds."
 msgstr "Anuncia o tempo incluindo segundos."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"O diálogo de opcións do complemento está aberto. Por favor péchao antes."
+"Os diálogos de opcións do complemento ou metadatos do streaming están "
+"abertos. Por favor péchaos antes."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -709,7 +717,14 @@ msgid "Playlist modification not available"
 msgstr "Modificación de lista de reprodución non dispoñible"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Non hai pista en reprodución."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "Non hai seguinte pista programada ou non hai pista en reprodución"
 
 #. Translators: Presented when next track information is unavailable.
@@ -721,10 +736,9 @@ msgid "Announces title of the next track if any"
 msgstr "Anuncia o título da seguinte pista se a hai"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Non se puido atopar a información da pista actual ou non hai pista en "
-"reprodución"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Non se puido atopar información da pista"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -801,6 +815,12 @@ msgstr ""
 "Presenta información das instantáneas de listaxes de reprodución como número "
 "de pistas e artistas principais"
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"O diálogo de opcións do complemento está aberto. no se puede cambiar de "
+"perfil"
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "Non se atoparon pistas, non se puido poñer o marcador"
@@ -875,12 +895,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Restablecer o complemento SPL Studio"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"O diálogo de opcións do complemento está aberto. no se puede cambiar de "
-"perfil"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1964,6 +1978,11 @@ msgstr "Reconto de oíntes: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Non hai pista en reprodución."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "Non se puido obter a información sobre transmisión de metadatos"
+
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"
 msgstr "Anuncia o estado do codificador da transmisión dende outros programas"
@@ -1979,186 +1998,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Axuda do SPL Controller"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "Non se atoparon codificadores"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr "Só pode estar activo un só tipo de codificador á vez"
-
-#. Translators: presented when at least one encoder is connected.
-#, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Codificadores conectados: {encodersConnected}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "Non hai codificadores conectados"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Opcións do codificador para {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "&Etiqueta de cadea"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "En&focar  Studio cando estea conectado"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Reproducir primeira pista cando estea conectado"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Habilitar &monitorización de conexión de fondo"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Reproducir &pitido de estado da conexión mentras se conecta"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Cambiar ó Studio tras se conectar"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Non cambiar a Studio despois de se conectar"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Conmuta se NVDA cambiará a Studio cando estea conectado a un servidor de "
-"streaming."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Reproducir primeira pista despois de conectar"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Non reproducir primeira pista despois de conectar"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Conmuta se Studio reproducirá ou non a primeira canción cando se conecte a "
-"un servidor de streaming."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Monitorizando codificador {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "O codificador {encoderNumber} non se monitorizará"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Monitorización de codificador cancelada"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr ""
-"Conmuta se NVDA monitorizará o codificador selecionado en segundo plano."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Etiquetador de cadea para {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Introduce a etiqueta para esta cadea"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Abre un diálogo para etiquetar o codificador selecionado."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Eliminador de etiqueta de cadea e opcións"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr ""
-"Introduce a posición do codificador que desexas eliminar ou eliminarase"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Abre un diálogo para borrar etiquetas de cadea e opcións dun codificador que "
-"foi eleminado."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Está aberto outro diálogo de opcións de codificador."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Amosa o diálogo configuración do codificador para configurar varias opcións "
-"do codificador como a etiqueta de cadea."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Se se premeu unha vez, anuncia a hora actual incluindo segundos. Se se "
-"premeu dúas veces, anuncia a data actual"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Posición: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Etiqueta: {label}"
-
-msgid "No stream label"
-msgstr "Non hai etiqueta de cadea"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Conectando..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Desconectando..."
-
-msgid "Connects to a streaming server."
-msgstr "Conecta a un servidor de streaming."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Opcións do Codificador: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Taxa de Transferencia: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2167,3 +2006,151 @@ msgid ""
 msgstr ""
 "Mellora o soporte para Station Playlist Studio.\n"
 "Ademáis, engade ordes globais para o estudio dende calquera parte."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "O diálogo de opcións do complemento está aberto. Por favor péchao antes."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Non se puido atopar a información da pista actual ou non hai pista en "
+#~ "reprodución"
+
+#~ msgid "No encoders found"
+#~ msgstr "Non se atoparon codificadores"
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr "Só pode estar activo un só tipo de codificador á vez"
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Codificadores conectados: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Non hai codificadores conectados"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Opcións do codificador para {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Etiqueta de cadea"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "En&focar  Studio cando estea conectado"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Reproducir primeira pista cando estea conectado"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Habilitar &monitorización de conexión de fondo"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Reproducir &pitido de estado da conexión mentras se conecta"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Cambiar ó Studio tras se conectar"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Non cambiar a Studio despois de se conectar"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Conmuta se NVDA cambiará a Studio cando estea conectado a un servidor de "
+#~ "streaming."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Reproducir primeira pista despois de conectar"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Non reproducir primeira pista despois de conectar"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Conmuta se Studio reproducirá ou non a primeira canción cando se conecte "
+#~ "a un servidor de streaming."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Monitorizando codificador {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "O codificador {encoderNumber} non se monitorizará"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Monitorización de codificador cancelada"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr ""
+#~ "Conmuta se NVDA monitorizará o codificador selecionado en segundo plano."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Etiquetador de cadea para {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Introduce a etiqueta para esta cadea"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Abre un diálogo para etiquetar o codificador selecionado."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Eliminador de etiqueta de cadea e opcións"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr ""
+#~ "Introduce a posición do codificador que desexas eliminar ou eliminarase"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Abre un diálogo para borrar etiquetas de cadea e opcións dun codificador "
+#~ "que foi eleminado."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Está aberto outro diálogo de opcións de codificador."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Amosa o diálogo configuración do codificador para configurar varias "
+#~ "opcións do codificador como a etiqueta de cadea."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Se se premeu unha vez, anuncia a hora actual incluindo segundos. Se se "
+#~ "premeu dúas veces, anuncia a data actual"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Posición: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Etiqueta: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Non hai etiqueta de cadea"
+
+#~ msgid "Connecting..."
+#~ msgstr "Conectando..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Desconectando..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Conecta a un servidor de streaming."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Opcións do Codificador: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Taxa de Transferencia: {transferRate}"

--- a/addon/locale/he/LC_MESSAGES/nvda.po
+++ b/addon/locale/he/LC_MESSAGES/nvda.po
@@ -30,6 +30,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "התגלתה גרסת ווינדוס ישנה"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "עקוב אחר הנתונים"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "מציג נתונים עבור כל העמודות במעקב שנבחר כעת"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "המיקרופון פעיל"
@@ -62,13 +70,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist Studio"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "ריק"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "עקוב אחר הנתונים"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,10 +112,6 @@ msgstr "{checkStatus}{header}: ריק"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "מציג נתונים עבור כל העמודות במעקב שנבחר כעת"
 
 msgid "Has comment"
 msgstr "קיימת הערה"
@@ -404,9 +409,13 @@ msgid "Announces time including seconds."
 msgstr "הקראת אורך הנגינה, כולל שניות."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
-msgstr "תיבת דו-שיח של הגדרות כבר פתוחה. נא לסגור אותה תחילה."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
+msgstr ""
+"תיבת דו-שיח של הגדרות התוסף או של זרימת הנתונם פתוחה כרגע. נא לסגור אותה "
+"תחילה."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -678,7 +687,14 @@ msgid "Playlist modification not available"
 msgstr "לא ניתן לשנות את רשימת הנגינה"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "אין רצועה בנגינה כעת."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "אין רצועה עתידה לנגן או בנגינה כעת"
 
 #. Translators: Presented when next track information is unavailable.
@@ -690,8 +706,9 @@ msgid "Announces title of the next track if any"
 msgstr "הקראת כותרת הרצועה הבאה, אם יש כזאת"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr "לא ניתן למצוא מידע על הרצועה הנוכחית או אין רצועה בנגינה כרגע"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "לא ניתן למצוא מידע על הרצועה הנוכחית"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -759,6 +776,10 @@ msgid ""
 "Presents playlist snapshot information such as number of tracks and top "
 "artists"
 msgstr "מציג מידע על רשימת השמעה כמו מספר רצועות ואמנים מובילים"
+
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr "תיבת דו-שיח התוסף פתוחה כרגע. לא ניתן להחליף פרופיל"
 
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
@@ -830,10 +851,6 @@ msgstr ""
 #, fuzzy
 msgid "SPL Studio add-on reset"
 msgstr "הגדרות תוסף הסטודיו"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr "תיבת דו-שיח התוסף פתוחה כרגע. לא ניתן להחליף פרופיל"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1857,6 +1874,11 @@ msgstr "מספר מאזינים:  {listenerCount}"
 msgid "There is no track playing."
 msgstr "אין רצועה בנגינה כעת."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "לא ניתן לפתוח את תיבת הדו-שיח של זרימת המטאדאטה"
+
 #. Translators: Input help message for a SPL Controller command.
 #, fuzzy
 msgid "Announces stream encoder status from other programs"
@@ -1871,177 +1893,6 @@ msgstr "מכריזה על מצב הסטודיו, כגון מצב השמעת רצ
 msgid "SPL Controller help"
 msgstr "עזרה על תוכנת SPL"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-#, fuzzy
-msgid "No encoders found"
-msgstr "לא נמצאה נקודת תחילת הניתוח"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr ""
-
-#. Translators: presented when at least one encoder is connected.
-#, fuzzy, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "שליטה על מנגנון הקידוד   {encoderNumber}"
-
-#. Translators: presented when no encoders are connected.
-#, fuzzy
-msgid "No encoders connected"
-msgstr "אין מנגנוני קידוד תחת שליטה"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "הגדרות קידוד עבור  {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "Stream &label"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "ה&עברת הפוקוס לסטודיו בעת התחברות"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&נגן את הרצועה הראשונה בעת התחברות"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "הפוך את ה&שליטה על ההתחברות לזמינה"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "השמע &צליל מצב בעת התחברות"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "העבר את הפוקוס לסטודיו בעת התחברות"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "אל תעביר את הפוקוס לסטודיו בעת התחברות"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr "מיתוג העברת הפוקוס לסטודיו על ידי NVDA בעת התחברות לשרת זרימה."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "נגן את הרצועה הראשונה בעת התחברות"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "אל תנגן את הרצועה הראשונה בעת התחברות"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr "מיתוג נגינת הרצועה הראשונה בעת התחברות לשרת זרימה."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "שליטה על מנגנון הקידוד   {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "לא תתבצע שליטה על מנגנון  {encoderNumber} הקידוד"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "השליטה על מנגנון הקידוד בוטלה"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "מיתוג שליטת NVDA על מנגנון הקידוד."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "הגדרת תוית עבור  {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "נא להקיש את התוית המגדירה את פריט הזרימה הזה"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "פתיחת תיבת דו-שיח להגדרת תויות."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "אפשרויות מחיקה של תויות ושל הגדרות"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "נא להקיש את מיקומו של מנגנון הקידוד שברצונך למחוק"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr "פתיחת תיבת דו-שיח למחיקת תויות והגדרות השייכות למנגנון קידוד שנמחק."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "תיבת דו-שיח של מנגנוני קידוד כבר פתוחה."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"מציג תיבת דו-שיח המאפשרת להגדיר מאפיינים שונים של מנגנוני הקידוד, כגון תויות."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr "לחיצה פעם אחת : הקראת השעה. לחיצה פעמיים : הקראת התאריך הנוכחי"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "מיקום: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "תוית: {label}"
-
-msgid "No stream label"
-msgstr "אין תוית לקטע"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "מתחבר..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "מתנתק..."
-
-msgid "Connects to a streaming server."
-msgstr "מתחבר לשרת זרימה."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "הגדרות מגנון זרימה:  {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "קצב העברה: : {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2050,3 +1901,138 @@ msgid ""
 msgstr ""
 "מנגיש את תוכנת StationPlaylist  Studio  .  \n"
 "בנוסף, מאפשר ביצוע פקודות מכל מקום אחר במחשב."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr "תיבת דו-שיח של הגדרות כבר פתוחה. נא לסגור אותה תחילה."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr "לא ניתן למצוא מידע על הרצועה הנוכחית או אין רצועה בנגינה כרגע"
+
+#, fuzzy
+#~ msgid "No encoders found"
+#~ msgstr "לא נמצאה נקודת תחילת הניתוח"
+
+#, fuzzy
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "שליטה על מנגנון הקידוד   {encoderNumber}"
+
+#, fuzzy
+#~ msgid "No encoders connected"
+#~ msgstr "אין מנגנוני קידוד תחת שליטה"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "הגדרות קידוד עבור  {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "Stream &label"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "ה&עברת הפוקוס לסטודיו בעת התחברות"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&נגן את הרצועה הראשונה בעת התחברות"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "הפוך את ה&שליטה על ההתחברות לזמינה"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "השמע &צליל מצב בעת התחברות"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "העבר את הפוקוס לסטודיו בעת התחברות"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "אל תעביר את הפוקוס לסטודיו בעת התחברות"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr "מיתוג העברת הפוקוס לסטודיו על ידי NVDA בעת התחברות לשרת זרימה."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "נגן את הרצועה הראשונה בעת התחברות"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "אל תנגן את הרצועה הראשונה בעת התחברות"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr "מיתוג נגינת הרצועה הראשונה בעת התחברות לשרת זרימה."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "שליטה על מנגנון הקידוד   {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "לא תתבצע שליטה על מנגנון  {encoderNumber} הקידוד"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "השליטה על מנגנון הקידוד בוטלה"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "מיתוג שליטת NVDA על מנגנון הקידוד."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "הגדרת תוית עבור  {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "נא להקיש את התוית המגדירה את פריט הזרימה הזה"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "פתיחת תיבת דו-שיח להגדרת תויות."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "אפשרויות מחיקה של תויות ושל הגדרות"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "נא להקיש את מיקומו של מנגנון הקידוד שברצונך למחוק"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr "פתיחת תיבת דו-שיח למחיקת תויות והגדרות השייכות למנגנון קידוד שנמחק."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "תיבת דו-שיח של מנגנוני קידוד כבר פתוחה."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "מציג תיבת דו-שיח המאפשרת להגדיר מאפיינים שונים של מנגנוני הקידוד, כגון "
+#~ "תויות."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr "לחיצה פעם אחת : הקראת השעה. לחיצה פעמיים : הקראת התאריך הנוכחי"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "מיקום: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "תוית: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "אין תוית לקטע"
+
+#~ msgid "Connecting..."
+#~ msgstr "מתחבר..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "מתנתק..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "מתחבר לשרת זרימה."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "הגדרות מגנון זרימה:  {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "קצב העברה: : {transferRate}"

--- a/addon/locale/hr/LC_MESSAGES/nvda.po
+++ b/addon/locale/hr/LC_MESSAGES/nvda.po
@@ -31,6 +31,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Stara Windows verzija"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Podaci snimke"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Prikazuje podatke svih stupaca u trenutačno odabranoj snimci"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Mikrofon aktivan"
@@ -62,13 +70,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "prazno"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Podaci snimke"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -103,10 +112,6 @@ msgstr "{checkStatus}{header}: prazno"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "Prikazuje podatke svih stupaca u trenutačno odabranoj snimci"
 
 msgid "Has comment"
 msgstr "Sadrži komentar"
@@ -413,11 +418,13 @@ msgid "Announces time including seconds."
 msgstr "Najavljuje vrijeme sa sekundama."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"Dijaloški okvir s postavkama dodatka je otvoren. Najprije zatvori dijaloški "
-"okvir s postavkama."
+"Već je otvoren dijaloški okvir s postavkama ili dijaloški okvir za "
+"internetski prijenos metapodataka. Najprije zatvori otvoreni dijaloški okvir."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -704,7 +711,14 @@ msgid "Playlist modification not available"
 msgstr "Promjena u popisu snimaka nije dostupna"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Niti jedna snimka ne svira."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "Nijedna snimka nije dalje planirana ili nijedna snimka ne svira"
 
 #. Translators: Presented when next track information is unavailable.
@@ -716,10 +730,9 @@ msgid "Announces title of the next track if any"
 msgstr "Najavljuje naslov sljedeće snimke, ako postoji"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Nije moguće pronaći informacije o trenutačnoj snimci ili nijedna snimka ne "
-"svira"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Nije moguće pronaći informacije o trenutačnoj snimci"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -794,6 +807,12 @@ msgid ""
 "artists"
 msgstr ""
 "Prikazuje statistiku popisa snimaka kao što su broj zapisa i izvođači na vrhu"
+
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"Dijaloški okvir s postavkama dodatka je otvoren, nije moguće promijeniti "
+"profile"
 
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
@@ -871,12 +890,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Resetiranje SPL Studio dodatka"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"Dijaloški okvir s postavkama dodatka je otvoren, nije moguće promijeniti "
-"profile"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1954,6 +1967,12 @@ msgstr "Broj slušatelja: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Niti jedna snimka ne svira."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr ""
+"Nije moguće dobiti informacije o stanju internetskog prijenosa metapodataka"
+
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"
 msgstr "Najavljuje stanje dekodera internetskog prijenosa drugih programa"
@@ -1969,184 +1988,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Pomoć za SPL Controller"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "Niti jedan dekoder nije pronađen"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr "U određenom trenutku može biti aktivna samo jedna vrsta dekodera"
-
-#. Translators: presented when at least one encoder is connected.
-#, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Povezani dekoderi: {encodersConnected}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "Nema povezanih dekodera"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Postavke dekodera za {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "&Oznaka internetskog prijenosa"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "&Fokusiraj na Studio nakon povezivanja"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Sviraj prvu snimku nakon povezivanja"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Aktiviraj &praćenje povezivanja u pozadini"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Sviraj &zvučni signal za stanje povezivanja tijekom povezivanja"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Prebaci se na Studio nakon povezivanja"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Nemoj se prebaciti na Studio nakon povezivanja"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Odlučuje hoće li se NVDA prebaciti na Studio nakon povezivanja sa serverom "
-"za internetski prijenos."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Sviraj prvu snimku nakon povezivanja"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Nemoj svirati prvu snimku nakon povezivanja"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Odlučuje hoće li Studio svirati prvu pjesmu nakon povezivanja sa serverom za "
-"internetski prijenos."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Praćenje dekodera {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Dekoder {encoderNumber} se neće pratiti"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Prekinuto praćenje dekodera"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "Odlučuje hoće li NVDA pratiti odabrani dekder u pozadini."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Označavanje internetskog prijenosa za {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Upiši oznaku za ovaj internetski prijenos"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Otvara dijaloški okvir za označavanje odabranog dekodera."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Brisač oznaka i postavki internetskih prijenosa"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "Upiši poziciju dekodera kojeg želiš izbrisati ili kojeg ćeš izbrisati"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Otvara dijaloški okvir za brisanje oznaka internetskih prijenosa i postavki "
-"izbrisanog dekodera."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Otvoren je jedan drugi dijaloški okvir s postavkama dekodera."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Prikazuje dijaloški okvir za konfiguriranje različitih postavki dekodera kao "
-"što je oznaka internetskog prijenosa."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Jednom pritisnuto, izgovara trenutačno vrijeme sa sekundama. Pritisnuto "
-"dvaput, izgovara trenutačni datum"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Pozicija: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Oznaka: {label}"
-
-msgid "No stream label"
-msgstr "Nema oznake internetskog prijenosa"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Povezivanje …"
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Prekidanje veze …"
-
-msgid "Connects to a streaming server."
-msgstr "Povezuje se na server za streaming."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Postavke enkodera: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Brzina prijenosa: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2155,3 +1996,151 @@ msgid ""
 msgstr ""
 "Poboljšava podršku za StationPlaylist Studio.\n"
 "Također, dodaje pristup naredbama za Studio s bilo kojeg mjesta."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "Dijaloški okvir s postavkama dodatka je otvoren. Najprije zatvori "
+#~ "dijaloški okvir s postavkama."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Nije moguće pronaći informacije o trenutačnoj snimci ili nijedna snimka "
+#~ "ne svira"
+
+#~ msgid "No encoders found"
+#~ msgstr "Niti jedan dekoder nije pronađen"
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr "U određenom trenutku može biti aktivna samo jedna vrsta dekodera"
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Povezani dekoderi: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Nema povezanih dekodera"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Postavke dekodera za {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Oznaka internetskog prijenosa"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&Fokusiraj na Studio nakon povezivanja"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Sviraj prvu snimku nakon povezivanja"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Aktiviraj &praćenje povezivanja u pozadini"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Sviraj &zvučni signal za stanje povezivanja tijekom povezivanja"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Prebaci se na Studio nakon povezivanja"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Nemoj se prebaciti na Studio nakon povezivanja"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Odlučuje hoće li se NVDA prebaciti na Studio nakon povezivanja sa "
+#~ "serverom za internetski prijenos."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Sviraj prvu snimku nakon povezivanja"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Nemoj svirati prvu snimku nakon povezivanja"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Odlučuje hoće li Studio svirati prvu pjesmu nakon povezivanja sa serverom "
+#~ "za internetski prijenos."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Praćenje dekodera {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Dekoder {encoderNumber} se neće pratiti"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Prekinuto praćenje dekodera"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Odlučuje hoće li NVDA pratiti odabrani dekder u pozadini."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Označavanje internetskog prijenosa za {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Upiši oznaku za ovaj internetski prijenos"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Otvara dijaloški okvir za označavanje odabranog dekodera."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Brisač oznaka i postavki internetskih prijenosa"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr ""
+#~ "Upiši poziciju dekodera kojeg želiš izbrisati ili kojeg ćeš izbrisati"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Otvara dijaloški okvir za brisanje oznaka internetskih prijenosa i "
+#~ "postavki izbrisanog dekodera."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Otvoren je jedan drugi dijaloški okvir s postavkama dekodera."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Prikazuje dijaloški okvir za konfiguriranje različitih postavki dekodera "
+#~ "kao što je oznaka internetskog prijenosa."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Jednom pritisnuto, izgovara trenutačno vrijeme sa sekundama. Pritisnuto "
+#~ "dvaput, izgovara trenutačni datum"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Pozicija: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Oznaka: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Nema oznake internetskog prijenosa"
+
+#~ msgid "Connecting..."
+#~ msgstr "Povezivanje …"
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Prekidanje veze …"
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Povezuje se na server za streaming."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Postavke enkodera: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Brzina prijenosa: {transferRate}"

--- a/addon/locale/pl/LC_MESSAGES/nvda.po
+++ b/addon/locale/pl/LC_MESSAGES/nvda.po
@@ -29,6 +29,15 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Starsza wersja systemu windows"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Dane utworu"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr ""
+"Predefiniuje dane dla wszystkich kolumn w aktualnie zaznaczonym utworze"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Mikrofon aktywny"
@@ -60,13 +69,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "pusto"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Dane utworu"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -101,11 +111,6 @@ msgstr "{checkStatus}{header}: Nie ma"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr ""
-"Predefiniuje dane dla wszystkich kolumn w aktualnie zaznaczonym utworze"
 
 msgid "Has comment"
 msgstr "Zawiera komentarz"
@@ -372,9 +377,12 @@ msgid "Announces time including seconds."
 msgstr "Oznajmia czas z uwzględnieniem sekund."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
-msgstr "Okno ustawień dodatku otwarte. Proszę, zamknij je najpierw"
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
+msgstr ""
+"Jedno z okien dodatku jest już aktywne. Proszę, zamknij najpierw je wszystkie"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -652,7 +660,14 @@ msgid "Playlist modification not available"
 msgstr "Modyfikacja listy odtwarzania niedostępna."
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Żaden utwór nie jest odtwarzany"
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "Żaden utwór nie jest odtwarzany lub zaplanowany"
 
 #. Translators: Presented when next track information is unavailable.
@@ -664,10 +679,9 @@ msgid "Announces title of the next track if any"
 msgstr "Wypowiada nazwę następnej ścieżki (jeśli adekwatne)"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Nie mogę odczytać informacji o obecnym utworze lub żaden utwór nie jest "
-"odtwarzany"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Informacja o obecnym utworze niedostępna."
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -740,6 +754,10 @@ msgstr ""
 "Wyświetla poglądowy stan playlisty. Pokazywane są informacje takie jak "
 "liczba utworów czy najczęściej grany artysta."
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr "Nie mogę przełączyć profilu; Okno dodatku aktywne"
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "Nic nie dodano, Nie mogę ustawić znacznika położenia"
@@ -809,10 +827,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Resetowanie dodatku SPL studio"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr "Nie mogę przełączyć profilu; Okno dodatku aktywne"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1819,6 +1833,11 @@ msgstr "Liczba słuchaczy: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Żaden utwór nie jest odtwarzany"
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "Nie można dostarczyć stanu strumieniowania metadanych"
+
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"
 msgstr "Oznajmia stan enkoderów strumieniowania z innych programów"
@@ -1832,184 +1851,6 @@ msgstr "Oznajmia status SPL z poziomu innych aplikacji"
 msgid "SPL Controller help"
 msgstr "Pomoc kontrolera SPL"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "Nie znaleziono enkoderów"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr ""
-
-#. Translators: presented when at least one encoder is connected.
-#, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Połączonych enkoderów: {encodersConnected}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "Nie ma podłączonych enkoderów"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Właściwości dla {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "Etykieta strumienia"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "Przełączaj do studia po połączeniu"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "Odtwarzaj pierwszy kawałek po połączeniu"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Włącz monitorowanie połączenia w tle"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Dźwięk podczas połączenia"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Przełączaj do studia po połączeniu"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Nie przełączaj do studia po połączeniu"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Przełącza, czy NVDA będzie przechodzić do studia po połączeniu z serwerem "
-"strumieniowania."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Odtwarzaj pierwszą ścieżkę po połączeniu"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Nie odtwarzaj pierwszej ścieżki po połączeniu"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Przełącza, czy Studio będzie odtwarzać pierwszą ścieżkę po połączeniu z "
-"serwerem strumieniowania."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Monitorowanie enkodera {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Enkoder {encoderNumber} nie będzie monitorowany"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Monitorowanie enkodera zaniechane"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "Przełącza monitorowanie wybranego enkodera w tle"
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Etykietownik strumienia dla {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Wprowadź etykietę tego strumienia"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Otwiera okno etykietowania wybranego enkodera.."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Usuwanie etykiet strumieni i ustawień"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "Podaj numer enkodera który chcesz usunąć"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Otwiera okno pozwalające usunąć etykiety i parametry uprzednio usuniętego "
-"enkodera"
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Inne okno właściwości enkodera jest otwarte"
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Wyświetla okno konfiguracji enkodera umożliwiające ustawienie jego "
-"rozmaitych właściwości"
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Wciśnięty raz, wypowiada aktualny czas z uwzględnieniem sekund. Podwójnie, "
-"aktualną datę."
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Pozycja: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Etykieta: {label}"
-
-msgid "No stream label"
-msgstr "Nie ma etykiety dla strumienia"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Łączenie..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Rozłączanie..."
-
-msgid "Connects to a streaming server."
-msgstr "Łączy z serwerem strumieniowania."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Ustawienie enkodera: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Szybkość: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2018,3 +1859,145 @@ msgid ""
 msgstr ""
 "Poprawia dostępność Station Playlist Studio.\n"
 "Ponadto, dodaje globalne komendy dla studia, dostępne z każdego miejsca."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr "Okno ustawień dodatku otwarte. Proszę, zamknij je najpierw"
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Nie mogę odczytać informacji o obecnym utworze lub żaden utwór nie jest "
+#~ "odtwarzany"
+
+#~ msgid "No encoders found"
+#~ msgstr "Nie znaleziono enkoderów"
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Połączonych enkoderów: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Nie ma podłączonych enkoderów"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Właściwości dla {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "Etykieta strumienia"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "Przełączaj do studia po połączeniu"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "Odtwarzaj pierwszy kawałek po połączeniu"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Włącz monitorowanie połączenia w tle"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Dźwięk podczas połączenia"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Przełączaj do studia po połączeniu"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Nie przełączaj do studia po połączeniu"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Przełącza, czy NVDA będzie przechodzić do studia po połączeniu z serwerem "
+#~ "strumieniowania."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Odtwarzaj pierwszą ścieżkę po połączeniu"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Nie odtwarzaj pierwszej ścieżki po połączeniu"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Przełącza, czy Studio będzie odtwarzać pierwszą ścieżkę po połączeniu z "
+#~ "serwerem strumieniowania."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Monitorowanie enkodera {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Enkoder {encoderNumber} nie będzie monitorowany"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Monitorowanie enkodera zaniechane"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Przełącza monitorowanie wybranego enkodera w tle"
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Etykietownik strumienia dla {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Wprowadź etykietę tego strumienia"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Otwiera okno etykietowania wybranego enkodera.."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Usuwanie etykiet strumieni i ustawień"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "Podaj numer enkodera który chcesz usunąć"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Otwiera okno pozwalające usunąć etykiety i parametry uprzednio usuniętego "
+#~ "enkodera"
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Inne okno właściwości enkodera jest otwarte"
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Wyświetla okno konfiguracji enkodera umożliwiające ustawienie jego "
+#~ "rozmaitych właściwości"
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Wciśnięty raz, wypowiada aktualny czas z uwzględnieniem sekund. "
+#~ "Podwójnie, aktualną datę."
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Pozycja: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Etykieta: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Nie ma etykiety dla strumienia"
+
+#~ msgid "Connecting..."
+#~ msgstr "Łączenie..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Rozłączanie..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Łączy z serwerem strumieniowania."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Ustawienie enkodera: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Szybkość: {transferRate}"

--- a/addon/locale/ro/LC_MESSAGES/nvda.po
+++ b/addon/locale/ro/LC_MESSAGES/nvda.po
@@ -29,6 +29,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Versiune veche de Windows"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Date despre melodie"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Prezintă datele pentru toate coloanele din piesa curent-selectată"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Microfon activ"
@@ -60,13 +68,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "gol"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Date despre melodie"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -101,10 +110,6 @@ msgstr "{checkStatus}{header}: gol"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: blank"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "Prezintă datele pentru toate coloanele din piesa curent-selectată"
 
 msgid "Has comment"
 msgstr "Are comentariu"
@@ -412,10 +417,13 @@ msgid "Announces time including seconds."
 msgstr "Anunță timpul care include secundele."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"Setările add-onului sunt deja deschise. Vă rugăm să le închideți mai întâi."
+"Setările de add-on sau de metadata streaming sunt deja deschise. Închideți "
+"mai întâi dialogurile deschise."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -703,7 +711,14 @@ msgid "Playlist modification not available"
 msgstr "Modificare playlist nedisponibilă"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Nicio melodie nu se redă."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "Nicio melodie următoare programată sau nicio melodie nu se redă"
 
 #. Translators: Presented when next track information is unavailable.
@@ -715,10 +730,9 @@ msgid "Announces title of the next track if any"
 msgstr "Anunță titlul următoarei melodi dacă există"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Nu se poate localiza informația despre melodia curentă sau nicio melodie nu "
-"se redă"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Nu se pot găsi informații despre melodia curentă"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -794,6 +808,11 @@ msgid ""
 msgstr ""
 "Prezintă informațiile listei de redare instantanee, cum ar fi numărul "
 "melodiilor și artiștii de top"
+
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"Dialogul cu setările addonului este deschis, nu se pot comuta profiluri"
 
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
@@ -871,11 +890,6 @@ msgstr ""
 #, fuzzy
 msgid "SPL Studio add-on reset"
 msgstr "Verifică actualizări addon"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr ""
-"Dialogul cu setările addonului este deschis, nu se pot comuta profiluri"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1961,6 +1975,11 @@ msgstr "Număr ascultători: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Nicio melodie nu se redă."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "Nu se pot obține informații despre starea metadatei streamingului"
+
 #. Translators: Input help message for a SPL Controller command.
 #, fuzzy
 msgid "Announces stream encoder status from other programs"
@@ -1977,188 +1996,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Ajutor controler SPL"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "Niciun encoder găsit"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr ""
-"Doar un tip de encoder poate fi activ, nu pot fi active mai multe tipuri "
-"simultan"
-
-#. Translators: presented when at least one encoder is connected.
-#, fuzzy, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Se monitorizează encoderul {encoderNumber}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "Niciun encoder nu este conectat"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Setări encoder pentru {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "&Etichetă emisie"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "&Focusare la studio când este conectat"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "Redă &prima melodie când s-a conectat la server"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Activează &monitorizarea pe fundal a conectării"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Redă &bipul de stare a conexiunii când se conectează"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Comutare la studio după conectare"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Nu comuta la studio după conectare"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Comută daca NVDA va schimba la Studio după conectarea la un server de "
-"streaming."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Redă prima melodie după conectare"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Nu reda prima melodie după conectare"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Comută dacă aplicația Studio va reda prima melodie după conectare la un "
-"server de streaming."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Se monitorizează encoderul {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Encoderul {encoderNumber} nu va fi monitorizat."
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Monitorizarea encoderului a fost anulată."
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "Comută dacă NVDA va monitoriza sau nu pe fundal encoderul selectat."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Etichetare emisie pentru {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Introdu eticheta pentru această emisie"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Deschide un dialog pentru a putea eticheta encoderul selectat."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Etichetare stream și ștergere setări"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr ""
-"Introduceți poziția encoderului pe care doriți să îl ștergeți sau pe care îl "
-"veți șterge"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Se deschide un dialog pentru a șterge etichetele de stream și setările unui "
-"encoder care este deja șters."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Un alt dialog cu setările encoderului este deschis."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Arată dialogul de configurare a encoderului pentru a configura diverse "
-"setări ale acestuia, cum ar fi etichete de stream."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Dacă este apăsat o dată, raportează ora curentă care include secundele. Dacă "
-"este apăsat de două ori, raportează data."
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Poziție: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Label: {label}"
-
-msgid "No stream label"
-msgstr "Nicio etichetă de emisie"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Se conectează..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Se deconectează..."
-
-msgid "Connects to a streaming server."
-msgstr "Conectează-te la un streaming server."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Setări encoder: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Frecvență de transfer: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2167,3 +2004,155 @@ msgid ""
 msgstr ""
 "Conține suport pentru StationPlaylist Studio.\n"
 "De asemenea, adaugă comenzi globale pentru studio de oriunde."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "Setările add-onului sunt deja deschise. Vă rugăm să le închideți mai "
+#~ "întâi."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Nu se poate localiza informația despre melodia curentă sau nicio melodie "
+#~ "nu se redă"
+
+#~ msgid "No encoders found"
+#~ msgstr "Niciun encoder găsit"
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr ""
+#~ "Doar un tip de encoder poate fi activ, nu pot fi active mai multe tipuri "
+#~ "simultan"
+
+#, fuzzy
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Se monitorizează encoderul {encoderNumber}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Niciun encoder nu este conectat"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Setări encoder pentru {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Etichetă emisie"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&Focusare la studio când este conectat"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "Redă &prima melodie când s-a conectat la server"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Activează &monitorizarea pe fundal a conectării"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Redă &bipul de stare a conexiunii când se conectează"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Comutare la studio după conectare"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Nu comuta la studio după conectare"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Comută daca NVDA va schimba la Studio după conectarea la un server de "
+#~ "streaming."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Redă prima melodie după conectare"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Nu reda prima melodie după conectare"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Comută dacă aplicația Studio va reda prima melodie după conectare la un "
+#~ "server de streaming."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Se monitorizează encoderul {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Encoderul {encoderNumber} nu va fi monitorizat."
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Monitorizarea encoderului a fost anulată."
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Comută dacă NVDA va monitoriza sau nu pe fundal encoderul selectat."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Etichetare emisie pentru {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Introdu eticheta pentru această emisie"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Deschide un dialog pentru a putea eticheta encoderul selectat."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Etichetare stream și ștergere setări"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr ""
+#~ "Introduceți poziția encoderului pe care doriți să îl ștergeți sau pe care "
+#~ "îl veți șterge"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Se deschide un dialog pentru a șterge etichetele de stream și setările "
+#~ "unui encoder care este deja șters."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Un alt dialog cu setările encoderului este deschis."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Arată dialogul de configurare a encoderului pentru a configura diverse "
+#~ "setări ale acestuia, cum ar fi etichete de stream."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Dacă este apăsat o dată, raportează ora curentă care include secundele. "
+#~ "Dacă este apăsat de două ori, raportează data."
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Poziție: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Label: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Nicio etichetă de emisie"
+
+#~ msgid "Connecting..."
+#~ msgstr "Se conectează..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Se deconectează..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Conectează-te la un streaming server."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Setări encoder: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Frecvență de transfer: {transferRate}"

--- a/addon/locale/ro/LC_MESSAGES/nvda.po
+++ b/addon/locale/ro/LC_MESSAGES/nvda.po
@@ -8,14 +8,14 @@ msgstr ""
 "Project-Id-Version: stationPlaylist 6.4\n"
 "Report-Msgid-Bugs-To: nvda-translations@freelists.org\n"
 "POT-Creation-Date: 2016-03-04 19:00+1000\n"
-"PO-Revision-Date: 2019-11-21 16:22-0800\n"
+"PO-Revision-Date: 2020-01-05 10:45+0200\n"
 "Last-Translator: Florian Ionașcu <florianionascu@hotmail.com>\n"
 "Language-Team: \n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.9\n"
+"X-Generator: Poedit 2.2.4\n"
 
 #. Translators: Presented when attempting to install StationPlaylist add-on on unsupported Windows releases.
 msgid ""
@@ -23,7 +23,7 @@ msgid ""
 "Service Pack 1 or later."
 msgstr ""
 "Folosiți o versiune mai veche de windows. Această versiune de supliment "
-"necesită windows 7 Service pack 1 sau mai nouă"
+"necesită windows 7 Service pack 1 sau mai nouă."
 
 #. Translators: Title of a dialog shown when installing StationPlaylist add-on on old Windows releases.
 msgid "Old Windows version"
@@ -57,9 +57,8 @@ msgstr ""
 #. Translators: Script category for StationPlaylist commands in input gestures dialog.
 #. Add-on summary, usually the user visible name of the addon.
 #. Translators: Summary for this add-on to be shown on installation and add-on information.
-#, fuzzy
 msgid "StationPlaylist"
-msgstr "StationPlaylist Studio"
+msgstr "StationPlaylist"
 
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
@@ -72,7 +71,7 @@ msgstr "Date despre melodie"
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
 msgid "{headerText} not found"
-msgstr "{headerText} negăsit."
+msgstr "{headerText} negăsit"
 
 #. Translators: location text for a playlist item (example: item 1 of 10).
 #, python-brace-format
@@ -368,11 +367,11 @@ msgstr "Setări SPL"
 #. Translators: Presented when library scan is complete.
 #, python-brace-format
 msgid "Scan complete with {scanCount} items"
-msgstr "Scan terminat cu {scanCount} elemente."
+msgstr "Scan terminat cu {scanCount} elemente"
 
 #. Translators: Presented when cart modes are toggled while cart explorer is on.
 msgid "Cart explorer is active"
-msgstr "Cart explorer este activat."
+msgstr "Cart explorer este activat"
 
 #. Translators: Presented when microphone was on for more than a specified time in microphone alarm dialog.
 msgid "Warning: Microphone active"
@@ -381,12 +380,12 @@ msgstr "Atenție: Microfon activ"
 #. Translators: Presented when end of introduction is approaching (example output: 5 sec left in track introduction).
 #, python-brace-format
 msgid "Warning: {seconds} sec left in track introduction"
-msgstr "Atenție: {seconds} secunde rămase în introducerea melodiiei."
+msgstr "Atenție: {seconds} secunde rămase în introducerea melodiiei"
 
 #. Translators: Presented when end of track is approaching.
 #, python-brace-format
 msgid "Warning: {seconds} sec remaining"
-msgstr "Atenție: {seconds} secunde rămase."
+msgstr "Atenție: {seconds} secunde rămase"
 
 #. Add the human-readable representation also.
 msgid "SPL mode"
@@ -448,7 +447,7 @@ msgstr "Fraza căutată nu a fostgăsită."
 
 #. Translators: Presented when a user attempts to find tracks but is not at the track list.
 msgid "Track finder is available only in track list."
-msgstr "căutarea melodiilor este disponibilă doar în lista de melodii."
+msgstr "Căutarea melodiilor este disponibilă doar în lista de melodii."
 
 #. Translators: Presented when a user attempts to find tracks but is not at the track list.
 msgid "Column search is available only in track list."
@@ -481,7 +480,7 @@ msgstr "Caută text în coloane."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Finds the next occurrence of the track with the name in the track list."
-msgstr "găsește următoarea apariție a pistei, cu numele de pe listă."
+msgstr "Găsește următoarea apariție a pistei, cu numele de pe listă."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Finds previous occurrence of the track with the name in the track list."
@@ -489,26 +488,25 @@ msgstr "Caută apariția anterioară a melodiei pe listă."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Locates track with duration within a time range"
-msgstr "găsește o pistă cu durata într-un interval de timp"
+msgstr "Găsește o pistă cu durata într-un interval de timp"
 
 #. Translators: Presented when cart explorer cannot be entered.
 msgid "You are not in playlist viewer, cannot enter cart explorer"
 msgstr ""
-"Nu ești în vizualizatorul playlist-ului, nu poți intra în cart explorer."
+"Nu ești în vizualizatorul playlist-ului, nu poți intra în cart explorer"
 
 #. Translators: presented when cart explorer could not be switched on.
 msgid "Some or all carts could not be assigned, cannot enter cart explorer"
 msgstr ""
-"Unele sau toate carturile nu pot fi atribuite. nu poți intra în cart "
-"explorer."
+"Unele sau toate carturile nu pot fi atribuite. nu poți intra în cart explorer"
 
 #. Translators: Presented when cart explorer is on.
 msgid "Entering cart explorer"
-msgstr "Intrare în cart explorer..."
+msgstr "Intrare în cart explorer"
 
 #. Translators: Presented when cart explorer is off.
 msgid "Exiting cart explorer"
-msgstr "Ieșire din Cart Explorer..."
+msgstr "Ieșire din Cart Explorer"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Toggles cart explorer to learn cart assignments."
@@ -516,11 +514,11 @@ msgstr "Comută Cart explorer pentru a afla atribuirile cartului."
 
 #. Translators: Presented when cart command is unavailable.
 msgid "Cart command unavailable"
-msgstr "Comandă cart nu este valabilă."
+msgstr "Comandă cart nu este valabilă"
 
 #. Translators: Presented when there is no cart assigned to a cart command.
 msgid "Cart unassigned"
-msgstr "Cart neatribuit."
+msgstr "Cart neatribuit"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Toggles library scan progress settings."
@@ -533,20 +531,20 @@ msgstr "Start scanare"
 #. Translators: Presented when library scanning is finished.
 #, python-brace-format
 msgid "{itemCount} items in the library"
-msgstr "Au fost găsite {itemCount} elemente în librarie."
+msgstr "{itemCount} elemente în librarie"
 
 #. Translators: Presented after library scan is done.
 #, python-brace-format
 msgid "Scan complete with {itemCount} items"
-msgstr "Scanare completă cu {itemCount} elemente."
+msgstr "Scanare completă cu {itemCount} elemente"
 
 #. Translators: Presented when library scan is in progress.
 msgid "Scanning"
-msgstr "Scanare..."
+msgstr "Scanare"
 
 #, python-brace-format
 msgid "{itemCount} items scanned"
-msgstr "{itemCount} elemente au fost scanate."
+msgstr "{itemCount} elemente au fost scanate"
 
 #. Translators: Presented when streaming dialog cannot be shown.
 msgid "Cannot open metadata streaming dialog"
@@ -569,7 +567,7 @@ msgstr ""
 msgid "Please return to playlist viewer before invoking this command."
 msgstr ""
 "Vă rugăm să reveniți la vizualizatorul de playlist-uri înainte de a invoca "
-"această comandă"
+"această comandă."
 
 #. Translators: an error message presented when performing some playlist commands while no playlist has been loaded.
 msgid "No playlist has been loaded."
@@ -579,8 +577,8 @@ msgstr "Nicio listă de redare nu a fost încărcată."
 msgid ""
 "Please select a track from playlist viewer before invoking this command."
 msgstr ""
-"Vă rugăm să o piesă din vizualizatorul de playlist-uri înainte de a invoca "
-"această comandă"
+"Vă rugăm să selectați o piesă din vizualizatorul de playlist-uri înainte de "
+"a invoca această comandă."
 
 #. Translators: Presented when playlist analyzer cannot be performed because user is not focused on playlist viewer.
 #, fuzzy
@@ -638,7 +636,7 @@ msgstr "Artiști de top: fără"
 
 #. Translators: one of the results for playlist snapshots feature, a heading for a group of items.
 msgid "Top artists:"
-msgstr "Top artiști"
+msgstr "Artiști de top:"
 
 #, python-brace-format
 msgid "No artist information ({artistCount})"
@@ -651,7 +649,7 @@ msgstr "{artistName} ({artistCount})"
 #. Translators: one of the results for playlist snapshots feature for announcing top track category in a playlist.
 #, python-format
 msgid "Top category: %s (%s)"
-msgstr "categorii de top: %s (%s)"
+msgstr "Categorii de top: %s(%s)"
 
 #. Translators: one of the results for playlist snapshots feature, a heading for a group of items.
 msgid "Categories:"
@@ -671,7 +669,7 @@ msgstr "Genuri de top: fără"
 
 #. Translators: one of the results for playlist snapshots feature, a heading for a group of items.
 msgid "Top genres:"
-msgstr "Genuri de top"
+msgstr "Genuri de top:"
 
 #, python-brace-format
 msgid "No genre information ({genreCount})"
@@ -690,7 +688,7 @@ msgstr "Listă de redare instantanee"
 msgid "Failed to locate Studio main window, cannot enter SPL Assistant"
 msgstr ""
 "Localizarea ferestrei principale a Studioului a eșuat, imposibil de deschis "
-"asistentul SPL."
+"asistentul SPL"
 
 #. Translators: Input help mode message for a layer command in StationPlaylist add-on.
 msgid ""
@@ -724,7 +722,7 @@ msgstr ""
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
-msgstr "Nu se pot găsi informații despre melodia curentă."
+msgstr "Nu se pot găsi informații despre melodia curentă"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Announces title of the currently playing track"
@@ -736,15 +734,15 @@ msgstr "Vremea și Temperatura nu sunt configurate"
 
 #. Translators: Presented when temperature information cannot be found.
 msgid "Weather information not found"
-msgstr "Informațiile despre vreme nu au fost găsite."
+msgstr "Informațiile despre vreme nu au fost găsite"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Announces temperature and weather information"
-msgstr "Anunță informațiile vremii și ale temperaturii."
+msgstr "Anunță informațiile vremii și ale temperaturii"
 
 #. Translators: Presented when there is no listener count information.
 msgid "Listener count not found"
-msgstr "Numărul de ascultători nu a putut fi identificat."
+msgstr "Numărul de ascultători nu a putut fi identificat"
 
 #. Translators: Presented when attempting to start library scan.
 msgid "Monitoring library scan"
@@ -752,7 +750,7 @@ msgstr "Se monitorizează scanarea librăriei"
 
 #. Translators: Presented when library scan is already in progress.
 msgid "Scanning is in progress"
-msgstr "Scanarea este în curs..."
+msgstr "Scanarea este în curs"
 
 #. Translators: Presented when track time analysis is turned on.
 msgid "Playlist analysis activated"
@@ -774,7 +772,7 @@ msgid ""
 "No track selected as start of analysis marker, cannot perform time analysis"
 msgstr ""
 "Nicio melodie selectată ca pornire a marcajului de analiză, imposibil de "
-"efectuat analiza timpului."
+"efectuat analiza timpului"
 
 #. Translators: Presented when time analysis is done for a number of tracks (example output: Tracks: 3, totaling 5:00).
 #, python-brace-format
@@ -787,7 +785,7 @@ msgid ""
 "current track"
 msgstr ""
 "Anunță durata totală a melodiilor între marcajul de start al analizei și "
-"melodia curentă."
+"melodia curentă"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid ""
@@ -799,7 +797,7 @@ msgstr ""
 
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
-msgstr "Nicio melodie găsită, nu se poate seta marcajul de loc."
+msgstr "Nicio melodie găsită, nu se poate seta marcajul de loc"
 
 #. Translators: Presented when place marker track is set.
 msgid "place marker set"
@@ -812,25 +810,25 @@ msgstr ""
 
 #. Translators: Presented when no place marker is found.
 msgid "No place marker found"
-msgstr "Niciun marcaj de loc găsit."
+msgstr "Niciun marcaj de loc găsit"
 
 #. Translators: Status message for metadata streaming.
 #, python-brace-format
 msgid "Metadata streaming on URL {URLPosition} enabled"
-msgstr "Emisia metadata pe linkul URL {URLPosition} activată."
+msgstr "Emisia metadata pe linkul URL {URLPosition} activată"
 
 #. Translators: Status message for metadata streaming.
 msgid "Metadata streaming on DSP encoder enabled"
-msgstr "Emisia metadata pe encoderul DSP activată."
+msgstr "Emisia metadata pe encoderul DSP activată"
 
 #. Translators: Status message for metadata streaming.
 #, python-brace-format
 msgid "Metadata streaming on URL {URLPosition} disabled"
-msgstr "Emisia metadata pe linkul URL {URLPosition} dezactivată."
+msgstr "Emisia metadata pe linkul URL {URLPosition} dezactivată"
 
 #. Translators: Status message for metadata streaming.
 msgid "Metadata streaming on DSP encoder disabled"
-msgstr "Emisia metadata pe encoderul DSP dezactivată."
+msgstr "Emisia metadata pe encoderul DSP dezactivată"
 
 #. Translators: Presented when attempting to announce specific columns but the focused item isn't a track.
 msgid "Not a track"
@@ -842,7 +840,7 @@ msgstr "Ajutor asistent SPL"
 
 #. Translators: The title for SPL Assistant help dialog.
 msgid "SPL Assistant help for JAWS layout"
-msgstr "Ajutor asistent SPL pentru aspectul Jaws."
+msgstr "Ajutor asistent SPL pentru aspectul JAWS"
 
 #. Translators: The title for SPL Assistant help dialog.
 msgid "SPL Assistant help for Window-Eyes layout"
@@ -882,7 +880,7 @@ msgstr ""
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
 msgid "Switching to {newProfileName}"
-msgstr "comutare la {newProfileName}"
+msgstr "Comutare la {newProfileName}"
 
 #. Translators: Presented when switching from instant switch profile to a previous profile.
 #, python-brace-format
@@ -891,7 +889,7 @@ msgstr "Întoarcere la {previousProfile}"
 
 #. Translators: Standard error title for configuration error.
 msgid "Studio add-on Configuration error"
-msgstr "Eroare la configurarea add-onului Studio."
+msgstr "Eroare la configurarea add-onului Studio"
 
 #. Translators: Message displayed if errors were found in encoder configuration file.
 msgid ""
@@ -926,7 +924,7 @@ msgstr "activ"
 #. Translators: A flag indicating the broadcast profile is an instant switch profile.
 #. Instant switch flag is set on another profile, so remove the flag first.
 msgid "instant switch"
-msgstr "Comutare instantanee"
+msgstr "comutare instantanee"
 
 #. Translators: A flag indicating the time-based triggers profile.
 #. Calling set profile flags with discard argument is always safe here.
@@ -939,15 +937,15 @@ msgstr "Doar profilul normal e în uz"
 
 #. Translators: Presented when trying to switch to an instant switch profile when the instant switch profile is not defined.
 msgid "No instant switch profile is defined"
-msgstr "Niciun profil de comutare instantanee definit."
+msgstr "Niciun profil de comutare instantanee definit"
 
 #. Translators: Presented when trying to switch to an instant switch profile when one is already using the instant switch profile.
 msgid "You are already in the instant switch profile"
-msgstr "Ești deja în profilul de comutare instantanee."
+msgstr "Ești deja în profilul de comutare instantanee"
 
 #. Translators: Presented when trying to switch to an instant switch profile when one is already using the instant switch profile.
 msgid "A profile trigger is already active"
-msgstr "Un trigger al profilului este deja activ."
+msgstr "Un declanșator de profiluri este deja activ"
 
 #. Translators: Title of a dialog displayed when the add-on starts reminding broadcasters to disable audio ducking.
 msgid "SPL Studio and audio ducking"
@@ -1035,26 +1033,26 @@ msgstr "Arată dialogul de bun venit când pornesc Studio"
 
 #. Translators: Reported when status announcement is set to beeps in SPL Studio.
 msgid "Status announcement beeps"
-msgstr "bipuri de anunțare a stării"
+msgstr "Bipuri de anunțare a stării"
 
 #. Translators: Reported when status announcement is set to beeps in SPL Studio.
 msgid "Beeps"
-msgstr "bipuri"
+msgstr "Bipuri"
 
 #. Translators: Reported when status announcement is set to beeps in SPL Studio.
 msgid "Status announcement words"
-msgstr "cuvinte de anunțare a stării"
+msgstr "Cuvinte de anunțare a stării"
 
 #. Translators: Reported when status announcement is set to beeps in SPL Studio.
 msgid "Words"
-msgstr "cuvinte"
+msgstr "Cuvinte"
 
 #. Translators: A setting in braille timer options.
 msgid "Braille timer off"
-msgstr "Cronometrul braille dezacrtivat."
+msgstr "Cronometrul braille dezactivat"
 
 msgid "Off"
-msgstr "dezactivat"
+msgstr "Dezactivat"
 
 #. Translators: A setting in braille timer options.
 msgid "Braille track endings"
@@ -1119,7 +1117,7 @@ msgstr "&Profil de emisie:"
 
 #. Borrowed logic from NVDA Core's speech panel (although there is no label for this read-only text).
 msgid "Normal profile is in use."
-msgstr "Profilul normal e în uz"
+msgstr "Profilul normal e în uz."
 
 #. Translators: The label of a button to copy a broadcast profile.
 msgid "Cop&y"
@@ -1225,7 +1223,7 @@ msgstr "Acest profil este un profil de comutare &instantanee"
 
 #. Translators: The label of a checkbox to toggle if selected profile is a time-based profile.
 msgid "This is a &time-based switch profile"
-msgstr "Acest profil este un profil bazat pe comutare în &timp."
+msgstr "Acest profil este un profil bazat pe comutare în &timp"
 
 msgid "Day"
 msgstr "Zi"
@@ -1268,11 +1266,11 @@ msgstr "&Bip pentru anunțurile stării"
 
 #. Translators: One of the message verbosity levels.
 msgid "beginner"
-msgstr "Începător"
+msgstr "începător"
 
 #. Translators: One of the message verbosity levels.
 msgid "advanced"
-msgstr "Avansat"
+msgstr "avansat"
 
 #. Translators: The label for a setting in SPL add-on dialog to set message verbosity.
 msgid "Message &verbosity:"
@@ -1304,11 +1302,11 @@ msgstr "Include &orele când se anunță durata melodiei sau a playlistului"
 
 #. Translators: The label for a setting in SPL add-on dialog to set vertical column.
 msgid "&Vertical column navigation announcement:"
-msgstr "&Anunțarea navigării coloanei verticale"
+msgstr "&Anunțarea navigării coloanei verticale:"
 
 #. Translators: One of the options for vertical column navigation denoting NVDA will announce current column positoin (e.g. second column position from the left).
 msgid "whichever column I am reviewing"
-msgstr "Indiferent de coloana pe care o revizuiesc"
+msgstr "indiferent de coloana pe care o revizuiesc"
 
 #. Translators: the label for a setting in SPL add-on settings to toggle category sound announcement.
 msgid "&Beep for different track categories"
@@ -1346,7 +1344,7 @@ msgid "Alarms Center"
 msgstr "Centrul de alarme"
 
 msgid "End of track alarm"
-msgstr "Alarma sfârșitului melodiiei."
+msgstr "Alarma sfârșitului melodiiei"
 
 msgid "Song intro alarm"
 msgstr "Alarma de intrare a melodiiei"
@@ -1358,13 +1356,13 @@ msgid "&End of track alarm in seconds"
 msgstr "Alarma pentru &sfârșit de melodie în secunde"
 
 msgid "&Notify when end of track is approaching"
-msgstr "&Notifică când sfârșitul melodiei se apropie."
+msgstr "&Notifică când sfârșitul melodiei se apropie"
 
 msgid "&Track intro alarm in seconds"
 msgstr "Alarma pentru î&nceput de melodie în secunde"
 
 msgid "&Notify when end of introduction is approaching"
-msgstr "&Notifică la apropierea sfârșitului introducerii."
+msgstr "&Notifică la apropierea sfârșitului introducerii"
 
 #. Translators: A dialog message to set microphone active alarm.
 msgid "&Microphone alarm in seconds (0 disables the alarm)"
@@ -1380,15 +1378,15 @@ msgstr "Centrul de alarme"
 
 #. Translators: One of the alarm notification options.
 msgid "beep"
-msgstr "Bip"
+msgstr "bip"
 
 #. Translators: One of the alarm notification options.
 msgid "message"
-msgstr "Mesaj"
+msgstr "mesaj"
 
 #. Translators: One of the alarm notification options.
 msgid "both beep and message"
-msgstr "Ambele, bip și mesaj"
+msgstr "atât bip cât și mesaj"
 
 #. Translators: The label for a setting in SPL add-on dialog to control alarm announcement type.
 msgid "&Alarm notification:"
@@ -1446,7 +1444,7 @@ msgid "Metadata streaming options"
 msgstr "Opţiuni emisie metadata"
 
 msgid "Select the URL for metadata streaming upon request."
-msgstr "Selectează URL-ul pentru cererea de emisie metadata"
+msgstr "Selectează URL-ul pentru cererea de emisie metadata."
 
 msgid "Check to enable metadata streaming, uncheck to disable."
 msgstr ""
@@ -1482,9 +1480,8 @@ msgstr "Notificare și conectare emisie &metadata"
 #. Only one loop is needed as helper.addLabelControl returns the checkbox itself and that can be appended.
 #. Add checkboxes for each stream, beginning with the DSP encoder.
 #. #76 (18.09-LTS): completely changed to use custom check list box (NVDA Core issue 7491).
-#, fuzzy
 msgid "&Select the URL for metadata streaming upon request:"
-msgstr "Selectează URL-ul pentru cererea de emisie metadata"
+msgstr "&Selectează URL-ul pentru cererea de emisie metadata:"
 
 #. Translators: title of a panel to configure column announcements (order and what columns should be announced).
 #, fuzzy
@@ -1529,19 +1526,16 @@ msgid "Playlist transcripts"
 msgstr "Listă de redare instantanee"
 
 #. Translators: Help text to select columns to be announced.
-#, fuzzy
 msgid ""
 "&Select columns to be included in playlist transcripts\n"
 "(artist and title are always included):"
 msgstr ""
-"Selectați informațiile care trebuie incluse la obținerea instantaneelor de "
-"redare.\n"
-"Numărul de track-uri și durata totală sunt întotdeauna incluse."
+"&Selectează coloanele care să fie incluse în transcrierile listei de redare\n"
+"(Artistul și titlul sunt întotdeauna incluse):"
 
 #. Translators: title of a panel to configure columns explorer settings.
-#, fuzzy
 msgid "Columns explorer"
-msgstr "explorer coloane"
+msgstr "Explorator de coloane"
 
 #. Translators: The label of a button to configure columns explorer slots (SPL Assistant, number row keys to announce specific columns).
 msgid "Columns E&xplorer..."
@@ -1558,7 +1552,7 @@ msgstr "Exploratorul de coloane pentru unealta &piesei."
 
 #. Translators: The title of Columns Explorer configuration dialog.
 msgid "Columns Explorer"
-msgstr "explorer coloane"
+msgstr "Explorer coloane"
 
 #. Translators: The title of Columns Explorer configuration dialog.
 msgid "Columns Explorer for Track Tool"
@@ -1596,15 +1590,15 @@ msgstr "Anunțare nume &melodie:"
 
 #. Translators: One of the track name announcement options.
 msgid "automatic"
-msgstr "Automat"
+msgstr "automat"
 
 #. Translators: One of the track name announcement options.
 msgid "while using other programs"
-msgstr "Când se utilizează alte programe"
+msgstr "când se utilizează alte programe"
 
 #. Translators: One of the track name announcement options.
 msgid "off"
-msgstr "Dezactivat"
+msgstr "dezactivat"
 
 #. Translators: the label for a setting in SPL add-on settings to announce player position for the current and next tracks.
 msgid ""
@@ -1757,7 +1751,7 @@ msgstr "C&oloană de căutare:"
 
 #. Translators: The title of a dialog to find tracks with duration within a specified range.
 msgid "Time range finder"
-msgstr "căutare distanță timp"
+msgstr "Căutare distanță timp"
 
 msgid "Minimum duration"
 msgstr "Durată minimă"
@@ -1778,17 +1772,17 @@ msgstr "Nicio melodie nu a fost găsită între durata minimă și cea maximă."
 
 #. Translators: Standard error title for find error (copy this from main nvda.po).
 msgid "Time range find error"
-msgstr "Eroare la căutarea distanței."
+msgstr "Eroare la căutarea distanței"
 
 msgid "Countdown started"
-msgstr "Numărătoarea inversă a început!"
+msgstr "Numărătoarea inversă a început"
 
 msgid "Timer complete"
-msgstr "Cronometru complet."
+msgstr "Cronometrare completă"
 
 #. Translators: presented when metadata streaming status cannot be obtained.
 msgid "Cannot obtain metadata streaming status information"
-msgstr "Nu se pot obține informații despre starea metadatei streamingului."
+msgstr "Nu se pot obține informații despre starea metadatei streamingului"
 
 #. Translators: Status message for metadata streaming.
 msgid "No metadata streaming URL's defined"
@@ -1855,17 +1849,15 @@ msgstr "Format de transcriere:"
 
 #. Translators: one of the playlist transcript actions.
 msgid "view transcript"
-msgstr "Vizualizează transcrierea"
+msgstr "vizualizează transcrierea"
 
 #. Translators: one of the playlist transcript actions.
-#, fuzzy
 msgid "copy to clipboard"
-msgstr "Comentariul melodiei copiat pe planșetă"
+msgstr "copiere pe planșetă"
 
 #. Translators: one of the playlist transcript actions.
-#, fuzzy
 msgid "save to file"
-msgstr "Profil de &bază:"
+msgstr "salvare în fișier"
 
 #. Translators: The label in playlist transcripts dialog to select transcript action.
 msgid "Transcript action:"
@@ -1873,7 +1865,6 @@ msgstr "Acțiune de transcriere:"
 
 #. Help message for SPL Controller
 #. Translators: the dialog text for SPL Controller help.
-#, fuzzy
 msgid ""
 "\n"
 "After entering SPL Controller, press:\n"
@@ -1915,7 +1906,9 @@ msgstr ""
 "I: Anunță numărul de ascultători.\n"
 "Q: Anunță starea informației Studio.\n"
 "R: Timpul rămas pentru melodia curentă.\n"
-"Shift+R: Progresul scanării librăriei"
+"Shift+R: Progresul scanării librăriei\n"
+"Tastele de funcție și rândul tastelor cu numere, cu sau fără Shift, Alt și "
+"Control: Redau cart-urile."
 
 #. Translators: Presented when StationPlaylist Studio is not running.
 msgid "SPL Studio is not running."
@@ -1957,7 +1950,7 @@ msgstr "Scanare completă cu {itemCount} elemente scanate"
 #. Translators: Announces number of items in the Studio's track library (example: 1000 items scanned).
 #, python-brace-format
 msgid "Scan complete with {itemCount} items scanned"
-msgstr "Scanare completă cu {itemCount} elemente scanate."
+msgstr "Scanare completă cu {itemCount} elemente scanate"
 
 #. Translators: Announces number of stream listeners.
 #, python-brace-format
@@ -1985,13 +1978,14 @@ msgid "SPL Controller help"
 msgstr "Ajutor controler SPL"
 
 #. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-#, fuzzy
 msgid "No encoders found"
-msgstr "Niciun marcaj de loc găsit."
+msgstr "Niciun encoder găsit"
 
 #. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
 msgid "Only one encoder type can be active at once"
 msgstr ""
+"Doar un tip de encoder poate fi activ, nu pot fi active mai multe tipuri "
+"simultan"
 
 #. Translators: presented when at least one encoder is connected.
 #, fuzzy, python-brace-format
@@ -1999,9 +1993,8 @@ msgid "Connected encoders: {encodersConnected}"
 msgstr "Se monitorizează encoderul {encoderNumber}"
 
 #. Translators: presented when no encoders are connected.
-#, fuzzy
 msgid "No encoders connected"
-msgstr "Niciun encoder nu este monitorizat."
+msgstr "Niciun encoder nu este conectat"
 
 #. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
 #, python-brace-format
@@ -2051,7 +2044,7 @@ msgstr ""
 
 #. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
 msgid "Play first track after connecting"
-msgstr "redă prima melodie după conectare"
+msgstr "Redă prima melodie după conectare"
 
 #. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
 msgid "Do not play first track after connecting"

--- a/addon/locale/sk/LC_MESSAGES/nvda.po
+++ b/addon/locale/sk/LC_MESSAGES/nvda.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: StationPlaylist 1.1-dev\n"
 "Report-Msgid-Bugs-To: nvda-translations@freelists.org\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2020-01-17 09:54+0100\n"
+"PO-Revision-Date: 2020-01-25 09:38+0100\n"
 "Last-Translator: Ondrej Rosík <ondrej.rosik@gmail.com>\n"
 "Language-Team: \n"
 "Language: sk\n"
@@ -71,7 +71,7 @@ msgstr "Station Playlist"
 #. Translators: Presented when column is out of range.
 #, python-brace-format
 msgid "Column {columnPosition} not found"
-msgstr ""
+msgstr "Nepodarilo sa nájsť {columnPosition}"
 
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
@@ -416,13 +416,12 @@ msgid "Announces time including seconds."
 msgstr "Oznámy aktuálny čas vrátane sekúnd."
 
 #. Translators: Presented when the add-on config dialog is opened.
-#, fuzzy
 msgid ""
 "The add-on settings dialog or another alarm dialog is opened. Please close "
 "the opened dialog first."
 msgstr ""
-"Máte otvorený dialóg s nastaveniami doplnku alebo informáciami o živom "
-"vysielaní. Najprv zatvorte toto okno."
+"Máte otvorený dialóg s nastaveniami doplnku alebo nastaveniami upozornení. "
+"Najprv zatvorte toto okno."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -700,14 +699,12 @@ msgstr "Informácia o úprave playlistu nie je dostupná"
 
 #. Translators: Presented when there is no information for the next track.
 #. Translators: Presented when there is no information for the current track.
-#, fuzzy
 msgid "No track is playing"
 msgstr "Nie je spustená žiadna skladba"
 
 #. Translators: Presented when there is no information for the next track.
-#, fuzzy
 msgid "No next track scheduled"
-msgstr "V pláne nie je ďalšia skladba, alebo teraz žiadna skladba nehrá"
+msgstr "V pláne nie je ďalšia skladba"
 
 #. Translators: Presented when next track information is unavailable.
 msgid "Cannot find next track information"
@@ -718,7 +715,6 @@ msgid "Announces title of the next track if any"
 msgstr "oznámi názov nasledujúcej skladby"
 
 #. Translators: Presented when there is no information for the current track.
-#, fuzzy
 msgid "Cannot locate current track information"
 msgstr "Nepodarilo sa zistiť informácie o aktuálnej skladbe"
 
@@ -1916,9 +1912,8 @@ msgid "There is no track playing."
 msgstr "Nie je spustená žiadna skladba"
 
 #. Translators: presented if encoder connection status cannot be obtained.
-#, fuzzy
 msgid "Cannot obtain encoder connection status"
-msgstr "Nepodarilo sa získať informácie o metadátach živého vysielania"
+msgstr "Nepodarilo sa získať informácie o stave enkodéra"
 
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"

--- a/addon/locale/sk/LC_MESSAGES/nvda.po
+++ b/addon/locale/sk/LC_MESSAGES/nvda.po
@@ -8,121 +8,497 @@ msgstr ""
 "Project-Id-Version: StationPlaylist 1.1-dev\n"
 "Report-Msgid-Bugs-To: nvda-translations@freelists.org\n"
 "POT-Creation-Date: \n"
-"PO-Revision-Date: 2014-12-10 13:42+0100\n"
+"PO-Revision-Date: 2020-01-17 09:54+0100\n"
 "Last-Translator: Ondrej Rosík <ondrej.rosik@gmail.com>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language-Team: \n"
+"Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.5.7\n"
+"X-Generator: Poedit 1.6.11\n"
 
-#. Translators: Script category for Station Playlist commands in input gestures dialog.
+#. Translators: Presented when attempting to install StationPlaylist add-on on unsupported Windows releases.
+msgid ""
+"You are using an older version of Windows. This add-on requires Windows 7 "
+"Service Pack 1 or later."
+msgstr ""
+"Používate staršiu verziu operačného systému Windows. Doplnok funguje od "
+"verzie Windows 7 Service pack 1."
+
+#. Translators: Title of a dialog shown when installing StationPlaylist add-on on old Windows releases.
+msgid "Old Windows version"
+msgstr "Staršia verzia operačného systému"
+
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Informácie o udalosti"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Zobrazí informácie o všetkých metadátach pre aktuálnu skladbu"
+
+#. Translators: Presented when microphone has been active for a while.
+msgid "Microphone active"
+msgstr "Mikrofón zapnutý"
+
+#, python-brace-format
+msgid "{header}: {content}"
+msgstr "{header}: {content}"
+
+#, python-brace-format
+msgid "{header}: blank"
+msgstr "{header}: prázdny"
+
+#, python-brace-format
+msgid "{header}: ()"
+msgstr "{header}: ()"
+
+#. Translators: input help mode message for column explorer commands.
+msgid ""
+"Pressing once announces data for a track column, pressing twice will present "
+"column data in a browse mode window"
+msgstr ""
+"Oznámy informácie o metadátach vybratej udalosti. Stlačené dvakrát rýchlo za "
+"sebou zobrazí informáciu v režime prehliadania."
+
+#. Translators: Script category for StationPlaylist add-on commands in input gestures dialog.
+#. Translators: Script category for StationPlaylist commands in input gestures dialog.
 #. Add-on summary, usually the user visible name of the addon.
 #. Translators: Summary for this add-on to be shown on installation and add-on information.
-msgid "Station Playlist Studio"
-msgstr "Station Playlist Studio"
+msgid "StationPlaylist"
+msgstr "Station Playlist"
 
-#. Translators: Presented when cart edit mode is toggled on while cart explorer is on.
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
+#. Translators: presented when column information for a track is empty.
+msgid "blank"
+msgstr "prázdny"
+
+#. Translators: Presented when a specific column header is not found.
+#, python-brace-format
+msgid "{headerText} not found"
+msgstr "{headerText} nebol nájdený."
+
+#. Translators: location text for a playlist item (example: item 1 of 10).
+#, python-brace-format
+msgid "Item {current} of {total}"
+msgstr "{current} z {total}"
+
+#. Translators: Presented when no track status is found in Studio 5.10.
+msgid "Status not found"
+msgstr "Stav nebol nájdený"
+
+#. Translators: Status information for a checked track in Studio 5.10.
+#, python-brace-format
+msgid "Status: {name}"
+msgstr "Stav: {name}"
+
+#. Translators: Standard message for announcing column content.
+#, python-brace-format
+msgid "{checkStatus}{header}: {content}"
+msgstr "{checkStatus}{header}: {content}"
+
+#. Translators: Spoken when column content is blank.
+#, python-brace-format
+msgid "{checkStatus}{header}: blank"
+msgstr "{checkStatus}{header}: prázdny"
+
+#. Translators: Brailled to indicate empty column content.
+#, python-brace-format
+msgid "{checkStatus}{header}: ()"
+msgstr "{checkStatus}{header}: ()"
+
+msgid "Has comment"
+msgstr "Obsahuje komentár"
+
+#. Translators: Presented when track comment has been copied to clipboard.
+msgid "Track comment copied to clipboard"
+msgstr "Komentár k udalosti skopírovaný do schránky"
+
+#. Translators: Presented when there is no track comment for the focused track.
+msgid "No comment"
+msgstr "Žiadny komentár"
+
+#. Translators: Presented when focused on a track other than an actual track (such as hour marker).
+msgid "Comments cannot be added to this kind of track"
+msgstr "K tejto udalosti nie je možné pridať komentár"
+
+#. Translators: The title of the track comments dialog.
+msgid "Track comment"
+msgstr "Komentár k udalosti"
+
+#. Translators: Input help message for track comment announcemnet command in SPL Studio.
+msgid ""
+"Announces track comment if any. Press twice to copy this information to the "
+"clipboard, and press three times to open a dialog to add, change or remove "
+"track comments"
+msgstr ""
+"Prečíta komentár k vybratej udalosti. Stlačené dvakrát rýchlo za sebou "
+"skopíruje komentár do schránky. Stlačené trikrát za sebou umožní pridať "
+"alebo upraviť komentár."
+
+#. Translators: The text of the help command in SPL Assistant layer.
+msgid ""
+"After entering SPL Assistant, press:\n"
+"A: Automation.\n"
+"C: Announce name of the currently playing track.\n"
+"D: Remaining time for the playlist.\n"
+"E: Overall metadata streaming status.\n"
+"Shift+1 through shift+4, shift+0: Metadata streaming status for DSP encoder "
+"and four additional URL's.\n"
+"H: Duration of trakcs in this hour slot.\n"
+"Shift+H: Duration of remaining trakcs in this hour slot.\n"
+"I: Listener count.\n"
+"K: Move to place marker track.\n"
+"Control+K: Set place marker track.\n"
+"L: Line-in status.\n"
+"M: Microphone status.\n"
+"N: Next track.\n"
+"P: Playback status.\n"
+"Shift+P: Pitch for the current track.\n"
+"R: Record to file.\n"
+"Shift+R: Monitor library scan.\n"
+"S: Scheduled time for the track.\n"
+"Shift+S: Time until the selected track will play.\n"
+"T: Cart edit/insert mode.\n"
+"U: Studio up time.\n"
+"W: Weather and temperature.\n"
+"Y: Playlist modification.\n"
+"1 through 0: Announce columns via Columns Explorer (0 is tenth column "
+"slot).\n"
+"F8: Take playlist snapshots such as track count, longest track and so on.\n"
+"Shift+F8: Obtain playlist transcripts in a variety of formats.\n"
+"F9: Mark current track as start of track time analysis.\n"
+"F10: Perform track time analysis.\n"
+"F12: Switch to an instant switch profile.\n"
+"Shift+F1: Open online user guide."
+msgstr ""
+"Po otvorení SPL asistenta máte k dispozícii tieto možnosti:\n"
+"A: Automatizácia.\n"
+"C: Názov prehrávanej skladby.\n"
+"D: Zostávajúci čas do konca aktuálneho playlistu.\n"
+"E: Stav živého vysielania.\n"
+"Skratky Shift+1 až shift+4, shift+0: Informácie o živom vysielaní DSP "
+"enkodéra a 4 pridané URL adresy.\n"
+"H: Dĺžka skladieb v aktuálnom hodinovom slote.\n"
+"Shift+H: Zostávajúci čas skladieb v aktuálnom hodinovom slote.\n"
+"I: Počet poslucháčov.\n"
+"K: Presunúť na skladbu so záložkou.\n"
+"Ctrl+K: Pridať záložku k skladbe.\n"
+"L: Stav Line-in.\n"
+"M: Stav mikrofónu.\n"
+"N: Nasledujúca skladba.\n"
+"P: Stav prehrávania.\n"
+"Shift+P: Tónina aktuálnej skladby.\n"
+"R: Stav nahrávania.\n"
+"Shift+R: Stav knižnice.\n"
+"S: Naplánovaný čas prehratia skladby.\n"
+"Shift+S: Zostávajúci čas do prehratia vybratej skladby.\n"
+"T: Pridanie a úprava jinglov.\n"
+"U: Celkový čas od reštartu SPL.\n"
+"W: Aktuálne počasie.\n"
+"Y: Stav úpravy playlistu.\n"
+"1 do 0: Oznamovanie hlavičiek(0 je hlavička 10).\n"
+"F8: Štatistika o aktuálnom playiste, ako napríklad počet skladieb, najdlhšia "
+"skladba...\n"
+"Shift+F8: Uložiť playlist v rôznych formátoch.\n"
+"F9: Označiť aktuálnu skladbu ako začiatok pre časovú analýzu.\n"
+"F10: Analyzovať čas skladieb.\n"
+"F12: prepnúť do iného profilu.\n"
+"Shift+F1: Online používateľská príručka"
+
+#. Translators: The text of the help command in SPL Assistant layer when JFW layer is active.
+msgid ""
+"After entering SPL Assistant, press:\n"
+"A: Automation.\n"
+"C: Toggle cart explorer.\n"
+"Shift+C: Announce name of the currently playing track.\n"
+"E: Overall metadata streaming status.\n"
+"Shift+1 through shift+4, shift+0: Metadata streaming status for DSP encoder "
+"and four additional URL's.\n"
+"Shift+E: Record to file.\n"
+"F: Track finder.\n"
+"H: Duration of trakcs in this hour slot.\n"
+"Shift+H: Duration of remaining trakcs in this hour slot.\n"
+"K: Move to place marker track.\n"
+"Control+K: Set place marker track.\n"
+"L: Listener count.\n"
+"Shift+L: Line-in status.\n"
+"M: Microphone status.\n"
+"N: Next track.\n"
+"P: Playback status.\n"
+"Shift+P: Pitch for the current track.\n"
+"R: Remaining time for the playlist.\n"
+"Shift+R: Monitor library scan.\n"
+"S: Scheduled time for the track.\n"
+"Shift+S: Time until the selected track will play.\n"
+"T: Cart edit/insert mode.\n"
+"U: Studio up time.\n"
+"W: Weather and temperature.\n"
+"Y: Playlist modification.\n"
+"1 through 0: Announce columns via Columns Explorer (0 is tenth column "
+"slot).\n"
+"F8: Take playlist snapshots such as track count, longest track and so on.\n"
+"Shift+F8: Obtain playlist transcripts in a variety of formats.\n"
+"F9: Mark current track as start of track time analysis.\n"
+"F10: Perform track time analysis.\n"
+"F12: Switch to an instant switch profile.\n"
+"Shift+F1: Open online user guide."
+msgstr ""
+"Po otvorení SPL asistenta máte k dispozícii tieto možnosti:\n"
+"A: Automatizácia.\n"
+"C: zapnúť a vypnúť prehliadač jinglov.\n"
+"Shift+C: Oznámy názov prehrávanej skladby.\n"
+"E: Stav živého vysielania.\n"
+"Skratky Shift+1 až shift+4, shift+0: Informácie o živom vysielaní DSP "
+"enkodéra a 4 pridané URL adresy.\n"
+"shift+E: Stav nahrávania.\n"
+"F: Vyhľadanie skladby.\n"
+"H: Dĺžka skladieb v aktuálnom hodinovom slote.\n"
+"Shift+H: Zostávajúci čas skladieb v aktuálnom hodinovom slote.\n"
+"K: Presunúť na skladbu so záložkou.\n"
+"Ctrl+K: Pridať záložku k skladbe.\n"
+"L: Počet poslucháčov.\n"
+"shift+L: Stav line-in.\n"
+"M: Stav mikrofónu.\n"
+"N: Nasledujúca skladba.\n"
+"P: Stav prehrávania.\n"
+"Shift+P: Tónina aktuálnej skladby.\n"
+"R: zostávajúci čas do konca playlistu.\n"
+"Shift+R: Stav knižnice.\n"
+"S: Naplánovaný čas prehratia skladby.\n"
+"Shift+S: Zostávajúci čas do prehratia vybratej skladby.\n"
+"T: Pridanie a úprava jinglov.\n"
+"U: Celkový čas od reštartu SPL.\n"
+"W: Aktuálne počasie.\n"
+"Y: Stav úpravy playlistu.\n"
+"1 do 0: Oznamovanie hlavičiek(0 je hlavička 10).\n"
+"F8: Štatistika o aktuálnom playiste, ako napríklad počet skladieb, najdlhšia "
+"skladba...\n"
+"Shift+F8: Uložiť playlist v rôznych formátoch.\n"
+"F9: Označiť aktuálnu skladbu ako začiatok pre časovú analýzu.\n"
+"F10: Analyzovať čas skladieb.\n"
+"F12: prepnúť do iného profilu.\n"
+"Shift+F1: Online používateľská príručka"
+
+#. Translators: The text of the help command in SPL Assistant layer when Window-Eyes layer is active.
+msgid ""
+"After entering SPL Assistant, press:\n"
+"A: Automation.\n"
+"C: Toggle cart explorer.\n"
+"Shift+C: Announce name of the currently playing track.\n"
+"D: Remaining time for the playlist.\n"
+"E: Elapsed time.\n"
+"F: Track finder.\n"
+"R: Remaining time for the currently playing track.\n"
+"G: Overall metadata streaming status.\n"
+"Shift+1 through shift+4, shift+0: Metadata streaming status for DSP encoder "
+"and four additional URL's.\n"
+"H: Duration of trakcs in this hour slot.\n"
+"Shift+H: Duration of remaining trakcs in this hour slot.\n"
+"K: Move to place marker track.\n"
+"Control+K: Set place marker track.\n"
+"L: Listener count.\n"
+"Shift+L: Line-in status.\n"
+"M: Microphone status.\n"
+"N: Next track.\n"
+"P: Playback status.\n"
+"Shift+P: Pitch for the current track.\n"
+"Shift+E: Record to file.\n"
+"Shift+R: Monitor library scan.\n"
+"S: Scheduled time for the track.\n"
+"Shift+S: Time until the selected track will play.\n"
+"T: Cart edit/insert mode.\n"
+"U: Studio up time.\n"
+"W: Weather and temperature.\n"
+"Y: Playlist modification.\n"
+"1 through 0: Announce columns via Columns Explorer (0 is tenth column "
+"slot).\n"
+"F8: Take playlist snapshots such as track count, longest track and so on.\n"
+"Shift+F8: Obtain playlist transcripts in a variety of formats.\n"
+"F9: Mark current track as start of track time analysis.\n"
+"F10: Perform track time analysis.\n"
+"F12: Switch to an instant switch profile.\n"
+"Shift+F1: Open online user guide."
+msgstr ""
+"Po otvorení SPL asistenta máte k dispozícii tieto možnosti:\n"
+"A: Automatizácia.\n"
+"C: zapnúť a vypnúť prehliadač jinglov.\n"
+"Shift+C: Oznámy názov prehrávanej skladby.\n"
+"D: Zostávajúci čas do konca playlistu.\n"
+"E: Uplynutý čas.\n"
+"F: Vyhľadanie skladby.\n"
+"R: Zostávajúci čas do konca skladby.\n"
+"G: Stav živého vysielania.\n"
+"Shift+1 do shift+4, shift+0: Stav živého vysielania pre DSP enkodér a 4 "
+"dodatočné URL adresy.\n"
+"H: Dĺžka skladieb v aktuálnom hodinovom slote.\n"
+"Shift+H: Zostávajúci čas skladieb v aktuálnom hodinovom slote.\n"
+"K: Presunúť na skladbu so záložkou.\n"
+"Ctrl+K: Pridať záložku k skladbe.\n"
+"L: Počet poslucháčov.\n"
+"shift+L: stav line-in.\n"
+"M: Stav mikrofónu.\n"
+"N: Nasledujúca skladba.\n"
+"P: Stav prehrávania.\n"
+"Shift+P: Tónina aktuálnej skladby.\n"
+"shift+E: Stav nahrávania.\n"
+"Shift+R: Stav knižnice.\n"
+"S: Naplánovaný čas prehratia skladby.\n"
+"Shift+S: Zostávajúci čas do prehratia vybratej skladby.\n"
+"T: Pridanie a úprava jinglov.\n"
+"U: Celkový čas od reštartu SPL.\n"
+"W: Aktuálne počasie.\n"
+"Y: Stav úpravy playlistu.\n"
+"1 do 0: Oznamovanie hlavičiek(0 je hlavička 10).\n"
+"F8: Štatistika o aktuálnom playiste, ako napríklad počet skladieb, najdlhšia "
+"skladba...\n"
+"Shift+F8: Uložiť playlist v rôznych formátoch.\n"
+"F9: Označiť aktuálnu skladbu ako začiatok pre časovú analýzu.\n"
+"F10: Analyzovať čas skladieb.\n"
+"F12: prepnúť do iného profilu.\n"
+"Shift+F1: Online používateľská príručka"
+
+msgid "SPL Studio Settings..."
+msgstr "Nastavenia SPL Studio..."
+
+msgid "SPL settings"
+msgstr "Nastavenia SPL"
+
+#. Translators: Presented when library scan is complete.
+#, python-brace-format
+msgid "Scan complete with {scanCount} items"
+msgstr "Načítanie dokončené - {scanCount} položiek"
+
+#. Translators: Presented when cart modes are toggled while cart explorer is on.
 msgid "Cart explorer is active"
 msgstr "Prehliadač jinglov je aktívny"
 
-#. Translators: Presented when cart edit mode is toggled off while cart explorer is on.
-msgid "Please reenter cart explorer to view updated cart assignments"
-msgstr "Aby ste videli zmeny, musíte zatvoriť a otvoriť prehliadač jinglov."
+#. Translators: Presented when microphone was on for more than a specified time in microphone alarm dialog.
+msgid "Warning: Microphone active"
+msgstr "Pozor: Mikrofón je zapnutý"
 
-#. Translators: Presented when remaining time is unavailable.
-msgid "Remaining time not available"
-msgstr "Zostávajúci čas nie je dostupný"
+#. Translators: Presented when end of introduction is approaching (example output: 5 sec left in track introduction).
+#, python-brace-format
+msgid "Warning: {seconds} sec left in track introduction"
+msgstr "Pozor: {seconds} sekúnd do konca úvodu"
 
-#. Translators: Input help mode message for a command in Station Playlist Studio.
+#. Translators: Presented when end of track is approaching.
+#, python-brace-format
+msgid "Warning: {seconds} sec remaining"
+msgstr "Pozor: {seconds} sekúnd ostáva"
+
+#. Add the human-readable representation also.
+msgid "SPL mode"
+msgstr "SPL režim"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Announces the remaining track time."
 msgstr "oznámi čas do konca skladby."
 
-#. Translators: Presented when elapsed time is unavailable.
-msgid "Elapsed time not available"
-msgstr "Uplynutý čas nie je dostupný"
-
-#. Translators: Input help mode message for a command in Station Playlist Studio.
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Announces the elapsed time for the currently playing track."
 msgstr "Oznámi uplynutý čas v skladbe."
 
-#. Translators: Presented when broadcaster time is unavailable.
-msgid "Broadcaster time not available"
-msgstr "Čas vysielania nie je dostupný"
-
-#. Translators: Input help mode message for a command in Station Playlist Studio.
-msgid "Announces broadcaster time."
-msgstr "oznámi vysielací čas."
-
-#. Translators: A dialog message to set end of track alarm (curAlarmSec is the current end of track alarm in seconds).
-msgid "Enter end of track alarm time in seconds (currently {curAlarmSec})"
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid ""
+"Announces broadcaster time. If pressed twice, reports minutes and seconds "
+"left to top of the hour."
 msgstr ""
-"zadajte čas upozornenia na koniec skladby v sekundách (teraz je "
-"{curAlarmSec})"
+"Oznamuje čas vysielania. Stlačené dvakrát rýchlo za sebou oznámy čas do "
+"konca hodiny."
 
-#. Translators: The title of end of track alarm dialog.
-msgid "End of track alarm"
-msgstr "Upozornenie na koniec skladby"
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Announces time including seconds."
+msgstr "Oznámy aktuálny čas vrátane sekúnd."
 
-#. Translators: The error message presented when incorrect alarm time value has been entered.
-msgid "Incorrect value entered."
-msgstr "Nesprávny údaj."
+#. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
+msgid ""
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
+msgstr ""
+"Máte otvorený dialóg s nastaveniami doplnku alebo informáciami o živom "
+"vysielaní. Najprv zatvorte toto okno."
 
-#. Translators: Standard title for error dialog (copy this from main nvda.po file).
-msgid "Error"
-msgstr "chyba"
-
-#. Translators: Input help mode message for a command in Station Playlist Studio.
-msgid "sets end of track alarm (default is 5 seconds)."
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Sets end of track alarm (default is 5 seconds)."
 msgstr "nastaví upozornenie pred koncom skladby (predvolene 5 sekúnd)."
 
-#. Translators: Reported when toggle announcement is set to beeps in SPL Studio.
-msgid "Toggle announcement beeps"
-msgstr "Režim pípanie"
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Sets song intro alarm (default is 5 seconds)."
+msgstr "nastaví upozornenie pred koncom intra skladby (predvolene 5 sekúnd)."
 
-#. Translators: Reported when toggle announcement is set to words in SPL Studio.
-msgid "Toggle announcement words"
-msgstr "Režim reč"
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Sets microphone alarm (default is 5 seconds)."
+msgstr "nastaví upozornenie na zapnutý mikrofón (predvolene 5 sekúnd)."
 
-#. Translators: Input help mode message for a command in Station Playlist Studio.
-msgid "Toggles option change announcements between words and beeps."
-msgstr "prepína medzi pípaním a rečou."
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Opens SPL Studio add-on configuration dialog."
+msgstr "Otvorí dialóg s nastaveniami doplnku pre SPL studio."
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Opens SPL Studio add-on welcome dialog."
+msgstr "Otvorí uvítací dialóg doplnku SPL Studio."
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Toggles between various braille timer settings."
+msgstr "Prepína zobrazenie času na braillovskom riadku."
 
 #. Translators: Standard dialog message when an item one wishes to search is not found (copy this from main nvda.po).
 msgid "Search string not found."
 msgstr "Text nebol nájdený."
 
-#. Translators: Standard error title for find error (copy this from main nvda.po).
-msgid "Find error"
-msgstr "Chyba vyhľadávania"
-
 #. Translators: Presented when a user attempts to find tracks but is not at the track list.
 msgid "Track finder is available only in track list."
 msgstr "prehľadávač skladieb je dostupný len v zozname skladieb."
+
+#. Translators: Presented when a user attempts to find tracks but is not at the track list.
+msgid "Column search is available only in track list."
+msgstr "Prezeranie metadát je dostupné len v zozname skladieb."
+
+#. Translators: Presented when a user attempts to find tracks but is not at the track list.
+msgid "Time range finder is available only in track list."
+msgstr "Vyhľadávanie podľa času je dostupné len v zozname skladieb."
 
 #. Translators: Presented when a user wishes to find a track but didn't add any tracks.
 msgid "You need to add at least one track to find tracks."
 msgstr "Aby bolo možné vyhľadávať, musíte pridať aspoň jednu skladbu."
 
-#. Translators: The text of the dialog for finding tracks.
-msgid "Enter the name of the track you wish to search."
-msgstr "zadajte názov skladby, ktorú hľadáte."
-
-#. Translators: The title of the find tracks dialog.
+#. Translators: Title for track finder dialog.
 msgid "Find track"
 msgstr "Nájsť skladbu"
 
-#. Translators: Input help mode message for a command in Station Playlist Studio.
+#. Translators: Title for column search dialog.
+msgid "Column search"
+msgstr "Vyhľadávanie metadát"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Finds a track in the track list."
 msgstr "Vyhľadá skladbu v zozname skladieb."
 
-#. Translators: Input help mode message for a command in Station Playlist Studio.
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Finds text in columns."
+msgstr "Vyhľadá text v metadátach."
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Finds the next occurrence of the track with the name in the track list."
 msgstr "Vyhľadá nasledujúci výskyt reťazca v názvoch skladieb."
 
-#. Translators: Input help mode message for a command in Station Playlist Studio.
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Finds previous occurrence of the track with the name in the track list."
 msgstr "Vyhľadá predchádzajúci výskyt reťazca v názvoch skladieb."
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Locates track with duration within a time range"
+msgstr "Nájde najvhodnejšiu skladbu podľa zadaného času"
+
+#. Translators: Presented when cart explorer cannot be entered.
+msgid "You are not in playlist viewer, cannot enter cart explorer"
+msgstr "Nie ste v playliste a preto nie je možné zobraziť prehliadač jinglov."
 
 #. Translators: presented when cart explorer could not be switched on.
 msgid "Some or all carts could not be assigned, cannot enter cart explorer"
@@ -137,7 +513,7 @@ msgstr "otváram prehliadač jinglov"
 msgid "Exiting cart explorer"
 msgstr "Opúšťam prehliadač jinglov"
 
-#. Translators: Input help mode message for a command in Station Playlist Studio.
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Toggles cart explorer to learn cart assignments."
 msgstr ""
 "otvára a zatvára prehliadač jinglov, v ktrom môťete sledovať pozície zvučiek."
@@ -150,30 +526,1353 @@ msgstr "Funkcia nie je dostupná"
 msgid "Cart unassigned"
 msgstr "položka nie je priradená"
 
-#. Translators: Input help mode message for a layer command in Station Playlist Studio.
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Toggles library scan progress settings."
+msgstr "Prepína oznamovanie o stave knižnice."
+
+#. Translators: Presented when library scan has started.
+msgid "Scan start"
+msgstr "Skenovanie spustené"
+
+#. Translators: Presented when library scanning is finished.
+#, python-brace-format
+msgid "{itemCount} items in the library"
+msgstr "{itemCount} položiek v knižnici"
+
+#. Translators: Presented after library scan is done.
+#, python-brace-format
+msgid "Scan complete with {itemCount} items"
+msgstr "Skenovanie dokončené - {itemCount} položiek"
+
+#. Translators: Presented when library scan is in progress.
+msgid "Scanning"
+msgstr "Skenujem"
+
+#, python-brace-format
+msgid "{itemCount} items scanned"
+msgstr "{itemCount} skenovaných položiek"
+
+#. Translators: Presented when streaming dialog cannot be shown.
+msgid "Cannot open metadata streaming dialog"
+msgstr "Nepodarilo sa otvoriť dialóg s informáciami o živom vysielaní"
+
+#. Translators: Presented when the add-on config dialog is opened.
+msgid ""
+"The add-on settings dialog or the metadata streaming dialog is opened. "
+"Please close the opened dialog first."
+msgstr ""
+"Máte otvorený dialóg s nastaveniami doplnku alebo informáciami o živom "
+"vysielaní. Najprv zatvorte toto okno."
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Opens a dialog to quickly enable or disable metadata streaming."
+msgstr ""
+"otvorí dialóg, v ktorom môžete rýchlo zapnúť a vypnúť vysielanie metadát."
+
+#. Translators: an error message presented when performing some playlist commands while focused on places other than Playlist Viewer.
+msgid "Please return to playlist viewer before invoking this command."
+msgstr "Najprv otvorte zobrazenie playlistu."
+
+#. Translators: an error message presented when performing some playlist commands while no playlist has been loaded.
+msgid "No playlist has been loaded."
+msgstr "Nie je otvorený žiadny playlist."
+
+#. Translators: an error message presented when performing some playlist commands while no tracks are selected/focused.
+msgid ""
+"Please select a track from playlist viewer before invoking this command."
+msgstr "Najprv vyberte skladbu."
+
+#. Translators: Presented when playlist analyzer cannot be performed because user is not focused on playlist viewer.
+msgid "Not in playlist viewer, cannot perform playlist analysis."
+msgstr "Nie je možné spustiť analýzu playlistu, pretože nie ste v playliste."
+
+#. Translators: reported when no playlist has been loaded when trying to perform playlist analysis.
+msgid "No playlist to analyze."
+msgstr "Žiadny playlist na analýzu."
+
+#. Translators: Presented when playlist analysis cannot be activated.
+msgid "No tracks are selected, cannot perform playlist analysis."
+msgstr ""
+"Nie sú vybraté žiadne skladby, preto nie je možné spustiť analýzu playlistu."
+
+#. Translators: one of the results for playlist snapshots feature for announcing total number of items in a playlist.
+#, python-brace-format
+msgid "Items: {playlistItemCount}"
+msgstr "Položky: {playlistItemCount}"
+
+#. Translators: one of the results for playlist snapshots feature for announcing total number of tracks in a playlist.
+#, python-brace-format
+msgid "Tracks: {playlistTrackCount}"
+msgstr "Skladby: {playlistTrackCount}"
+
+#. Translators: one of the results for playlist snapshots feature for announcing total duration of a playlist.
+#, python-brace-format
+msgid "Duration: {playlistTotalDuration}"
+msgstr "Dĺžka: {playlistTotalDuration}"
+
+#. Translators: one of the results for playlist snapshots feature for announcing shortest track name and duration of a playlist.
+#, python-brace-format
+msgid "Shortest: {playlistShortestTrack}"
+msgstr "najkratšia: {playlistShortestTrack}"
+
+#. Translators: one of the results for playlist snapshots feature for announcing longest track name and duration of a playlist.
+#, python-brace-format
+msgid "Longest: {playlistLongestTrack}"
+msgstr "Najdlhšia: {playlistLongestTrack}"
+
+#. Translators: one of the results for playlist snapshots feature for announcing average duration for tracks in a playlist.
+#, python-brace-format
+msgid "Average: {playlistAverageDuration}"
+msgstr "Priemerná dĺžka skladby: {playlistAverageDuration}"
+
+#. Translators: one of the results for playlist snapshots feature for announcing top artist in a playlist.
+#, python-format
+msgid "Top artist: %s (%s)"
+msgstr "Najhranejší interpret: %s (%s)"
+
+msgid "Top artist: none"
+msgstr "Žiadny najhranejší interpret"
+
+#. Translators: one of the results for playlist snapshots feature, a heading for a group of items.
+msgid "Top artists:"
+msgstr "Najhranejší interpreti:"
+
+#, python-brace-format
+msgid "No artist information ({artistCount})"
+msgstr "Žiadne informácie o interpretoh ({artistCount})"
+
+#, python-brace-format
+msgid "{artistName} ({artistCount})"
+msgstr "{artistName} ({artistCount})"
+
+#. Translators: one of the results for playlist snapshots feature for announcing top track category in a playlist.
+#, python-format
+msgid "Top category: %s (%s)"
+msgstr "Najviac hraná kategória: %s (%s)"
+
+#. Translators: one of the results for playlist snapshots feature, a heading for a group of items.
+msgid "Categories:"
+msgstr "Kategórie:"
+
+#, python-brace-format
+msgid "{categoryName} ({categoryCount})"
+msgstr "{categoryName} ({categoryCount})"
+
+#. Translators: one of the results for playlist snapshots feature for announcing top genre in a playlist.
+#, python-format
+msgid "Top genre: %s (%s)"
+msgstr "Najhranejší žáner: %s (%s)"
+
+msgid "Top genre: none"
+msgstr "Žiadne najhranejšie žánre"
+
+#. Translators: one of the results for playlist snapshots feature, a heading for a group of items.
+msgid "Top genres:"
+msgstr "Najhranejšie žánre:"
+
+#, python-brace-format
+msgid "No genre information ({genreCount})"
+msgstr "Žiadne informácie o žánroch ({genreCount})"
+
+#, python-brace-format
+msgid "{genreName} ({genreCount})"
+msgstr "{genreName} ({genreCount})"
+
+#. Translators: The title of a window for displaying playlist snapshots information.
+#. Translators: title of a panel to configure playlist snapshot information.
+msgid "Playlist snapshots"
+msgstr "Štatistika playlistu"
+
+#. Translators: Presented when SPL Assistant cannot be invoked.
+msgid "Failed to locate Studio main window, cannot enter SPL Assistant"
+msgstr ""
+"Nepodarilo sa nájsť okno SPL studio a nepodarilo sa spustiť SPL asistenta"
+
+#. Translators: Input help mode message for a layer command in StationPlaylist add-on.
 msgid ""
 "The SPL Assistant layer command. See the add-on guide for more information "
 "on available commands."
 msgstr "Podmnožina príkazov. Pozrite návod k doplnku pre podrobnosti."
 
+#. Translators: presented when playlist modification message isn't shown.
+msgid "Playlist modification not available"
+msgstr "Informácia o úprave playlistu nie je dostupná"
+
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Nie je spustená žiadna skladba"
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "V pláne nie je ďalšia skladba, alebo teraz žiadna skladba nehrá"
+
+#. Translators: Presented when next track information is unavailable.
+msgid "Cannot find next track information"
+msgstr "Nepodarilo sa zistiť informáciu o nasledujúcej skladbe"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Announces title of the next track if any"
+msgstr "oznámi názov nasledujúcej skladby"
+
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Nepodarilo sa zistiť informácie o aktuálnej skladbe"
+
+#. Translators: Presented when current track information is unavailable.
+msgid "Cannot find current track information"
+msgstr "Nepodarilo sa zistiť informácie o aktuálnej skladbe"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Announces title of the currently playing track"
+msgstr "Oznámi názov práve hrajúcej skladby"
+
+#. Translators: Presented when there is no weather or temperature information.
+msgid "Weather and temperature not configured"
+msgstr "Nie je nastavené zobrazenie aktuálneho počasia"
+
+#. Translators: Presented when temperature information cannot be found.
+msgid "Weather information not found"
+msgstr "Informácia o počasí nebola nájden"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid "Announces temperature and weather information"
+msgstr "Oznámy aktuálne počasie"
 
 #. Translators: Presented when there is no listener count information.
 msgid "Listener count not found"
 msgstr "Nepodarilo sa nájsť informáciu o počte poslucháčov"
 
-#. Used ANSI version, as Wide char version always returns 0.
-#. Translators: Presented when Station Playlist Studio is not running.
+#. Translators: Presented when attempting to start library scan.
+msgid "Monitoring library scan"
+msgstr "Stav knižnice"
+
+#. Translators: Presented when library scan is already in progress.
+msgid "Scanning is in progress"
+msgstr "prebieha skenovanie knižnice"
+
+#. Translators: Presented when track time analysis is turned on.
+msgid "Playlist analysis activated"
+msgstr "Zapnutá analýza playlistu"
+
+#. Translators: Presented when track time analysis is turned off.
+msgid "Playlist analysis deactivated"
+msgstr "Vypnutá analýza playlistu"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid ""
+"Marks focused track as start marker for various playlist analysis commands"
+msgstr "Označí vybratú skladbu ako počiatočnú pre analýzu playlistu"
+
+#. Translators: Presented when track time analysis cannot be used because start marker is not set.
+msgid ""
+"No track selected as start of analysis marker, cannot perform time analysis"
+msgstr "Najprv vyberte počiatočnú skladbu"
+
+#. Translators: Presented when time analysis is done for a number of tracks (example output: Tracks: 3, totaling 5:00).
+#, python-brace-format
+msgid "Tracks: {numberOfSelectedTracks}, totaling {totalTime}"
+msgstr "{numberOfSelectedTracks} skladieb, Celkový čas: {totalTime}"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid ""
+"Announces total length of tracks between analysis start marker and the "
+"current track"
+msgstr "Oznámy celkový čas od počiatočnej po aktuálnu skladbu"
+
+#. Translators: Input help mode message for a command in StationPlaylist add-on.
+msgid ""
+"Presents playlist snapshot information such as number of tracks and top "
+"artists"
+msgstr ""
+"Zobrazí štatistiku playllistu ako napríklad počet skladieb a najhranejšieho "
+"interpreta"
+
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr ""
+"Nie je možné zmeniť profil, máte otvorený dialóg s nastaveniami doplnku"
+
+#. Translators: Presented when place marker cannot be set.
+msgid "No tracks found, cannot set place marker"
+msgstr "Nenašli sa žiadne skladby, nemôžem nastaviť počiatočnú skladbu"
+
+#. Translators: Presented when place marker track is set.
+msgid "place marker set"
+msgstr "Začiatok označený"
+
+#. Translators: Presented when attempting to place a place marker on an unsupported track.
+msgid "This track cannot be used as a place marker track"
+msgstr "Túto udalosť nie je možné označiť ako počiatočnú skladbu"
+
+#. Translators: Presented when no place marker is found.
+msgid "No place marker found"
+msgstr "Žiadna počiatočná skladba"
+
+#. Translators: Status message for metadata streaming.
+#, python-brace-format
+msgid "Metadata streaming on URL {URLPosition} enabled"
+msgstr "Zapnuté vysielanie Metadát na {URLPosition}"
+
+#. Translators: Status message for metadata streaming.
+msgid "Metadata streaming on DSP encoder enabled"
+msgstr "Zapnuté vysielanie metadát na DSP enkodéry"
+
+#. Translators: Status message for metadata streaming.
+#, python-brace-format
+msgid "Metadata streaming on URL {URLPosition} disabled"
+msgstr "Vypnuté vysielanie metadát na {URLPosition}"
+
+#. Translators: Status message for metadata streaming.
+msgid "Metadata streaming on DSP encoder disabled"
+msgstr "Vypnuté vysielanie metadát na DSP enkodéry"
+
+#. Translators: Presented when attempting to announce specific columns but the focused item isn't a track.
+msgid "Not a track"
+msgstr "nie je skladba"
+
+#. Translators: The title for SPL Assistant help dialog.
+msgid "SPL Assistant help"
+msgstr "Pomocník SPL asistenta"
+
+#. Translators: The title for SPL Assistant help dialog.
+msgid "SPL Assistant help for JAWS layout"
+msgstr "Pomocník SPL asistenta rozloženie pre čítač obrazovky JAWS"
+
+#. Translators: The title for SPL Assistant help dialog.
+msgid "SPL Assistant help for Window-Eyes layout"
+msgstr "Pomocník SPL asistenta, rozloženie pre Window-Eyes "
+
+#. Translators: A message informing users that Studio is not running so certain commands will not work.
+msgid "Studio main window not found"
+msgstr "Nepodarilo sa nájsť hlavné okno SPL"
+
+#. Translators: The name of the default (normal) profile.
+msgid "Normal profile"
+msgstr "Predvolený profil"
+
+#. Translators: Message displayed when attempting to reset Studio add-on settings while an instant switch or time-based profile is active.
+msgid ""
+"An instant switch or time-based profile is active. Resetting Studio add-on "
+"settings means normal profile will become active and switch profile settings "
+"will be left in unpredictable state. Are you sure you wish to reset Studio "
+"add-on settings to factory defaults?"
+msgstr ""
+"Máte aktivovaný profil, ktorý ste aktivovali ručne alebo sa aktivoval podľa "
+"zadaného času. Ak obnovíte nastavenia doplnku, aktivuje sa predvolený "
+"profil. Želáte si pokračovať?"
+
+#. Translators: The title of the confirmation dialog for Studio add-on settings reset.
+msgid "SPL Studio add-on reset"
+msgstr "Obnovenie nastavení doplnku SPL studio"
+
+#. Translators: Presented when switch to instant switch profile was successful.
+#, python-brace-format
+msgid "Switching to {newProfileName}"
+msgstr "Prepínam na {newProfileName}"
+
+#. Translators: Presented when switching from instant switch profile to a previous profile.
+#, python-brace-format
+msgid "Returning to {previousProfile}"
+msgstr "Vraciam sa na {previousProfile}"
+
+#. Translators: Standard error title for configuration error.
+msgid "Studio add-on Configuration error"
+msgstr "Chyba nastavení doplnku SPL Studio"
+
+#. Translators: Message displayed if errors were found in encoder configuration file.
+msgid ""
+"Your encoder settings had errors and were reset to defaults. If you have "
+"stream labels configured for various encoders, please add them again."
+msgstr ""
+"V nastaveniach enkodéra sa našli chyby a preto boli nastavenia obnovené. Ak "
+"ste používali rôzne názvy pre enkodéry, nastavte ich znovu."
+
+#. Translators: Title of the encoder settings error dialog.
+msgid "Encoder settings error"
+msgstr "Chyba nastavení enkodéra"
+
+#. Translators: Message presented indicating missing time-based profiles.
+#, python-brace-format
+msgid ""
+"Could not locate the following time-based profile(s):\n"
+"{profiles}"
+msgstr ""
+"Nemôžem nájsť tieto časové profily:\n"
+"{profiles}"
+
+#. Translators: The title of a dialog shown when some time-based profiles doesn't exist.
+msgid "Time-based profiles missing"
+msgstr "Chýbajúci časový profil"
+
+#. Translators: A flag indicating the currently active broadcast profile.
+msgid "active"
+msgstr "Aktívny"
+
+#. Translators: A flag indicating the broadcast profile is an instant switch profile.
+#. Instant switch flag is set on another profile, so remove the flag first.
+msgid "instant switch"
+msgstr "Ručná aktivácia"
+
+#. Translators: A flag indicating the time-based triggers profile.
+#. Calling set profile flags with discard argument is always safe here.
+msgid "time-based"
+msgstr "Časová aktivácia"
+
+#. Translators: announced when only normal profile is in use.
+msgid "Only normal profile is in use"
+msgstr "Používa sa len predvolený profil"
+
+#. Translators: Presented when trying to switch to an instant switch profile when the instant switch profile is not defined.
+msgid "No instant switch profile is defined"
+msgstr "Nemáte nastavený žiadny ručný profil"
+
+#. Translators: Presented when trying to switch to an instant switch profile when one is already using the instant switch profile.
+msgid "You are already in the instant switch profile"
+msgstr "Profil je už aktivovaný"
+
+#. Translators: Presented when trying to switch to an instant switch profile when one is already using the instant switch profile.
+msgid "A profile trigger is already active"
+msgstr "Profil je už aktívny"
+
+#. Translators: Title of a dialog displayed when the add-on starts reminding broadcasters to disable audio ducking.
+msgid "SPL Studio and audio ducking"
+msgstr "Upozornenie"
+
+#. Translators: A message displayed if audio ducking should be disabled.
+msgid ""
+"NVDA 2016.1 and later allows NVDA to decrease volume of background audio "
+"including that of Studio.\n"
+"\t\tIn order to not disrupt the listening experience of your listeners, "
+"please disable audio ducking either by:\n"
+"\t\t* Opening synthesizer dialog in NVDA and selecting 'no ducking' from "
+"audio ducking mode combo box.\n"
+"\t\t* Press NVDA+Shift+D to set it to 'no ducking'."
+msgstr ""
+"NVDA od verzie 2016.1 povoľuje stišovanie ostatných zvukov systému. Toto má "
+"vplyv aj na zvuk SPL Studio.\n"
+"\t\tAby ste nestišovali zvuk pre vášich poslucháýčov, bude lepšie túto "
+"funkciu dočasne vypnúť:\n"
+"\t\tV nastaveniach hlasového výstupu aktivujte tlačidlo zmeniť. Potom "
+"nájdite zoznamový rámik Režim automatického stíšenia a vyberte nestíšiť.\n"
+"\t\tAlebo vypnite stíšenie skratkou nvda+shift+d."
+
+#. Translators: A checkbox to turn off audio ducking reminder message.
+msgid "Do not show this message again"
+msgstr "Nezobrazovať viac túto správu"
+
+#. Translators: A message giving basic information about the add-on.
+msgid ""
+"Welcome to StationPlaylist add-on for NVDA,\n"
+"your companion to broadcasting with SPL Studio using NVDA screen reader.\n"
+"\n"
+"Highlights of StationPlaylist add-on include:\n"
+"* Layer commands for obtaining status information.\n"
+"* Various ways to examine track columns.\n"
+"* Various ways to find tracks.\n"
+"* Cart Explorer to learn cart assignments.\n"
+"* Comprehensive settings and documentation.\n"
+"* Completely free, open-source and community-driven.\n"
+"* And much more.\n"
+"\n"
+"Visit www.stationplaylist.com for details on StationPlaylist suite of "
+"applications.\n"
+"Visit StationPlaylist entry on NVDA Community Add-ons page (addons.nvda-"
+"project.org) for more information on the add-on and to read the "
+"documentation.\n"
+"Want to see this dialog again? Just press Alt+NVDA+F1 while using Studio to "
+"return to this dialog.\n"
+"Have something to say about the add-on? Press Control+NVDA+hyphen (-) to "
+"send a feedback to the developer of this add-on using your default email "
+"program.\n"
+"\n"
+"Thank you."
+msgstr ""
+"Vitajte v doplnku pre StationPlaylist add-on,\n"
+"Vášho sprievodcu pri vysielaní internetového rádia cez SPL Studio.\n"
+"\n"
+"Prednosti tohto doplnku zahŕňajú:\n"
+"* Príkazy na zistenie stavu funkcii.\n"
+"* Príkazy na zistenie metadát v skladbách.\n"
+"* Viaceré možnosti vyhľadávania v zozname skladieb.\n"
+"* Prezeranie v zozname jinglov.\n"
+"* Podrobné nastavenia a dokumentáciu.\n"
+"* Všetko zdarma, s otvoreným kódom a podporou širokej komunity.\n"
+"* A oveľa viac.\n"
+"\n"
+"Podrobnosti o sete aplikácii Station playlist nájdete na www.stationplaylist."
+"com.\n"
+"Podrobnosti a návod k tomuto doplnku nájdete na stránke addons.nvda-project."
+"org.\n"
+"Tento dialóg môžete kedykoľvek zobraziť skratkou Alt+NVDA+F1 v okne SPL.\n"
+"Ak mi chcete poslať e-mail, stlačte Ctrl+NVDA+-.\n"
+"\n"
+"Ďakujem."
+
+#. Translators: Title of a dialog displayed when the add-on starts presenting basic information, similar to NVDA's own welcome dialog.
+msgid "Welcome to StationPlaylist add-on"
+msgstr "Vitajte v doplnku Station Playlist"
+
+#. Translators: A checkbox to show welcome dialog.
+msgid "Show welcome dialog when I start Studio"
+msgstr "Po spustení SPL zobraziť uvítací dialóg"
+
+#. Translators: Reported when status announcement is set to beeps in SPL Studio.
+msgid "Status announcement beeps"
+msgstr "Režim pípanie"
+
+#. Translators: Reported when status announcement is set to beeps in SPL Studio.
+msgid "Beeps"
+msgstr "pípanie"
+
+#. Translators: Reported when status announcement is set to beeps in SPL Studio.
+msgid "Status announcement words"
+msgstr "Režim reč"
+
+#. Translators: Reported when status announcement is set to beeps in SPL Studio.
+msgid "Words"
+msgstr "reč"
+
+#. Translators: A setting in braille timer options.
+msgid "Braille timer off"
+msgstr "Nezobrazovať čas na braillovskom riadku"
+
+msgid "Off"
+msgstr "vypnuté"
+
+#. Translators: A setting in braille timer options.
+msgid "Braille track endings"
+msgstr "Čas konca skladby"
+
+#. Translators: A setting in braille timer options.
+msgid "Outro"
+msgstr "Outro"
+
+#. Translators: A setting in braille timer options.
+msgid "Braille intro endings"
+msgstr "Koniec úvodu skladby"
+
+#. Translators: A setting in braille timer options.
+msgid "Intro"
+msgstr "Intro"
+
+#. Translators: A setting in braille timer options.
+msgid "Braille intro and track endings"
+msgstr "Intro a konce skladieb"
+
+#. Translators: A setting in braille timer options.
+#. Translators: One of the track comment notification settings.
+msgid "Both"
+msgstr "oboje"
+
+#. Translators: A setting in library scan announcement options.
+msgid "Do not announce library scans"
+msgstr "neoznamovať skenovanie knižnice"
+
+#. Translators: A setting in library scan announcement options.
+msgid "Announce start and end of a library scan"
+msgstr "Oznamovať začiatok a koniec skenovania knižnice"
+
+#. Translators: One of the library scan announcement settings.
+msgid "Start and end only"
+msgstr "Len začiatok a koniec"
+
+#. Translators: A setting in library scan announcement options.
+msgid "Announce the progress of a library scan"
+msgstr "Oznamovať priebeh skenovania knižnice"
+
+#. Translators: One of the library scan announcement settings.
+msgid "Scan progress"
+msgstr "Oznamovať priebeh skenovania"
+
+#. Translators: A setting in library scan announcement options.
+msgid "Announce progress and item count of a library scan"
+msgstr "oznamovať priebeh a počet naskenovaných položiek"
+
+#. Translators: One of the library scan announcement settings.
+msgid "Scan count"
+msgstr "Oznamovať počet položiek"
+
+#. Translators: title of a panel to configure broadcast profiles.
+msgid "Broadcast profiles"
+msgstr "Vysielacie profily"
+
+#. Translators: The label for a setting in SPL add-on dialog to select a broadcast profile.
+msgid "Broadcast &profile:"
+msgstr "Vysielací &Profil:"
+
+#. Borrowed logic from NVDA Core's speech panel (although there is no label for this read-only text).
+msgid "Normal profile is in use."
+msgstr "Používate predvolený profil."
+
+#. Translators: The label of a button to copy a broadcast profile.
+msgid "Cop&y"
+msgstr "Kop&írovať"
+
+#. Translators: The label for a setting in SPL Add-on settings to configure countdown seconds before switching profiles.
+msgid "Countdown seconds before switching profiles"
+msgstr "Pred zmenou profilu odpočítať sekundy"
+
+msgid ""
+"The selected profile is different from currently active broadcast profile. "
+"Settings will be applied to the selected profile instead."
+msgstr ""
+"Máte aktivovaný iný profil, ako ste vybrali. Nastavenia sa ale uložia do "
+"práve vybratého profilu."
+
+msgid "Apply settings"
+msgstr "Použiť"
+
+#. #70 (18.07): in wxPython 4, name for the value keyword argument for text entry dialog constructor has changed.
+#. Translators: The label of a field to enter a new name for a broadcast profile.
+msgid "New name:"
+msgstr "Nový názov:"
+
+#. Translators: The title of the dialog to rename a profile.
+msgid "Rename Profile"
+msgstr "Premenovať profil"
+
+#. Translators: An error displayed when renaming a configuration profile
+#. and a profile with the new name already exists.
+#. Translators: An error displayed when the user attempts to create a profile which already exists.
+msgid "That profile already exists. Please choose a different name."
+msgstr "Profil s týmto názvom už existuje. Zadajte iný názov."
+
+#. Translators: Message reported when attempting to delete a profile while a profile is triggered.
+msgid ""
+"An instant switch profile might be active or you are in the midst of a "
+"broadcast. If so, please press SPL Assistant, F12 to switch back to a "
+"previously active profile before opening add-on settings to delete a profile."
+msgstr ""
+"Máte aktívny profil alebo práve prebieha vysielanie. Najprv sa vráďte k "
+"predvolenému profilu: V SPL asistentovy stlačte F12. Následne môžete "
+"odstrániť profil."
+
+#. Translators: Title of a dialog shown when profile cannot be deleted.
+msgid "Profile delete error"
+msgstr "Chyba pri odstránení profilu"
+
+#. Translators: The confirmation prompt displayed when the user requests to delete the active broadcast profile.
+msgid ""
+"You are about to delete the currently active profile. Select yes if you wish "
+"to proceed."
+msgstr "Chystáte sa vymazať aktívny profil. Ak chcete pokračovať, stlačte áno."
+
+#. Translators: The title of the confirmation dialog for deletion of a profile.
+msgid "Delete active profile"
+msgstr "Odstránenie aktívneho profilu"
+
+#. Translators: The confirmation prompt displayed when the user requests to delete a broadcast profile.
+msgid "Are you sure you want to delete this profile? This cannot be undone."
+msgstr "Naozaj chcete odstrániť profil?"
+
+#. Translators: The title of the confirmation dialog for deletion of a profile.
+msgid "Confirm Deletion"
+msgstr "Potvrdenie odstránenia"
+
+#. Translators: Message reported when attempting to change profile switch trigger while broadcasting.
+msgid "You cannot change profile switch triggers in the midst of a broadcast."
+msgstr "Nemôžete spustiť profil počas aktívneho živého vysielania."
+
+#. Translators: Title of a dialog shown when profile trigger cannot e changd.
+msgid "Profile triggers"
+msgstr "Spúšťače profilu"
+
+#. Translators: The title of the dialog to create a new broadcast profile.
+msgid "New Profile"
+msgstr "Nový profil"
+
+#. Translators: The title of the dialog to copy a broadcast profile.
+msgid "Copy Profile"
+msgstr "Skopírovať profil"
+
+#. Translators: The label of a field to enter the name of a new broadcast profile.
+msgid "Profile name:"
+msgstr "Názov profilu:"
+
+#. Translators: The label for a setting in SPL add-on dialog to select a base  profile for copying.
+msgid "&Base profile:"
+msgstr "&Základný profil:"
+
+#. Translators: The title of the broadcast profile triggers dialog.
+#, python-brace-format
+msgid "Profile triggers for {profileName}"
+msgstr "Spúšťače pre profil {profileName}"
+
+#. Translators: The label of a checkbox to toggle if selected profile is an instant switch profile.
+msgid "This is an &instant switch profile"
+msgstr "&ručná aktivácia"
+
+#. Translators: The label of a checkbox to toggle if selected profile is a time-based profile.
+msgid "This is a &time-based switch profile"
+msgstr "&Časová aktivácia"
+
+msgid "Day"
+msgstr "Deň"
+
+msgid "Time"
+msgstr "čas"
+
+msgid "Hour"
+msgstr "hodina"
+
+msgid "Minute"
+msgstr "minúta"
+
+msgid "Duration in minutes"
+msgstr "Dĺžka trvania v minútach"
+
+#. Translators: Presented if another profile occupies a time slot set by the user.
+msgid ""
+"A profile trigger already exists for the entered time slot. Please choose a "
+"different date or time."
+msgstr "V tomto čase sa už aktivuje iný profil. Vyberte iný čas."
+
+#. Er, did you specify a date?
+msgid ""
+"The time-based profile checkbox is checked but no switch dates are given. "
+"Please either specify switch date(s) or uncheck time-based profile checkbox."
+msgstr ""
+"Začiarkli ste možnosť časovo aktivovaného profilu, ale neuviedli ste dátum. "
+"Odčiarknite príslušné políčko alebo zrušte časovú aktiváciu profilu."
+
+#. Translators: title of a panel to configure various general add-on settings such as top and bottom announcement for playlists.
+msgid "General"
+msgstr "Všeobecné"
+
+#. Translators: the label for a setting in SPL add-on settings to set status announcement between words and beeps.
+msgid "&Beep for status announcements"
+msgstr "Oznamovať &Pípaním"
+
+#. Translators: One of the message verbosity levels.
+msgid "beginner"
+msgstr "Začiatočník"
+
+#. Translators: One of the message verbosity levels.
+msgid "advanced"
+msgstr "Pokročilý"
+
+#. Translators: The label for a setting in SPL add-on dialog to set message verbosity.
+msgid "Message &verbosity:"
+msgstr "&Výrečnosť:"
+
+#. Translators: One of the braille timer settings.
+msgid "Track ending"
+msgstr "Koniec skladby"
+
+#. Translators: One of the braille timer settings.
+msgid "Track intro"
+msgstr "Intro skladby"
+
+#. Translators: One of the braille timer settings.
+msgid "Track intro and ending"
+msgstr "Intro a koniec skladby"
+
+#. Translators: The label for a setting in SPL add-on dialog to control braille timer.
+msgid "&Braille timer:"
+msgstr "Na &Braillovskom riadku zobraziť:"
+
+#. Translators: The label for a setting in SPL add-on dialog to control library scan announcement.
+msgid "&Library scan announcement:"
+msgstr "&Skenovanie knižnice:"
+
+#. Translators: the label for a setting in SPL add-on settings to announce time including hours.
+msgid "Include &hours when announcing track or playlist duration"
+msgstr "Pri oznamovaní dĺžky skladieb a playlistu oznamovať &Hodiny"
+
+#. Translators: The label for a setting in SPL add-on dialog to set vertical column.
+msgid "&Vertical column navigation announcement:"
+msgstr "Oznamovanie počas &vertikálnej navigácie v metadátach:"
+
+#. Translators: One of the options for vertical column navigation denoting NVDA will announce current column positoin (e.g. second column position from the left).
+msgid "whichever column I am reviewing"
+msgstr "ktoré metadáta prezerám"
+
+#. Translators: the label for a setting in SPL add-on settings to toggle category sound announcement.
+msgid "&Beep for different track categories"
+msgstr "&Pípať pri rôznych kategóriách skladieb"
+
+#. Translators: One of the track comment notification settings.
+msgid "Message"
+msgstr "reč"
+
+#. Translators: One of the track comment notification settings.
+msgid "Beep"
+msgstr "Pípať"
+
+#. Translators: the label for a setting in SPL add-on settings to set how track comments are announced.
+msgid "&Track comment announcement:"
+msgstr "Oznamovanie &komentárov:"
+
+#. Translators: the label for a setting in SPL add-on settings to toggle top and bottom notification.
+msgid "Notify when located at &top or bottom of playlist viewer"
+msgstr "Oznamovať začiatok a &Koniec playlistu"
+
+#. Translators: the label for a setting in SPL add-on settings to enable requests alert.
+msgid "Play a sound when listener &requests arrive"
+msgstr "Upozorniť na želanie &Poslucháča"
+
+#. Translators: Text of the dialog when another alarm dialog is open.
+msgid "Another alarm dialog is open."
+msgstr "Máte otvorený dialóg s nastavením upozornení."
+
+#. Now the actual alarm dialog code.
+#. 8.0: Apart from level 0 (all settings shown), levels change title.
+msgid "Alarms Center"
+msgstr "Upozornenia"
+
+msgid "End of track alarm"
+msgstr "Upozornenie na koniec skladby"
+
+msgid "Song intro alarm"
+msgstr "Intro"
+
+msgid "Microphone alarm"
+msgstr "Mikrofón"
+
+msgid "&End of track alarm in seconds"
+msgstr "&Upozornenie na koniec skladby (v sekundách)"
+
+msgid "&Notify when end of track is approaching"
+msgstr "&Upozorniť na koniec skladby"
+
+msgid "&Track intro alarm in seconds"
+msgstr "In&tro skladby v sekundách"
+
+msgid "&Notify when end of introduction is approaching"
+msgstr "Upozor&niť na koniec intra"
+
+#. Translators: A dialog message to set microphone active alarm.
+msgid "&Microphone alarm in seconds (0 disables the alarm)"
+msgstr "Upozornenie na zapnutý &mikrofón v sekúndách (0 je vypnuté)"
+
+msgid "Microphone alarm &interval in seconds"
+msgstr "&Interval upozornenia na zapnutý mikrofón v sekúndách"
+
+#. Translators: title of a panel to configure various alarms and related settings.
+msgid "Alarms"
+msgstr "Upozornenia"
+
+#. Translators: One of the alarm notification options.
+msgid "beep"
+msgstr "Pípať"
+
+#. Translators: One of the alarm notification options.
+msgid "message"
+msgstr "reč"
+
+#. Translators: One of the alarm notification options.
+msgid "both beep and message"
+msgstr "Pípať a čítať"
+
+#. Translators: The label for a setting in SPL add-on dialog to control alarm announcement type.
+msgid "&Alarm notification:"
+msgstr "Upozornenie"
+
+#. Translators: Help text for playlist snapshots dialog.
+msgid ""
+"Select information to be included when obtaining playlist snapshots.\n"
+"\t\tTrack count and total duration are always included."
+msgstr ""
+"Aké informácie chcete zobrazovať v štatistike playlistu?\n"
+"\t\tPočet skladieb a dĺžka playlistu sa zobrazia vždy."
+
+#. Translators: the label for a setting in SPL add-on settings to include shortest and longest track duration in playlist snapshots window.
+msgid "Shortest and longest tracks"
+msgstr "Najdlhšia a najkratšia skladba"
+
+#. Translators: the label for a setting in SPL add-on settings to include average track duration in playlist snapshots window.
+msgid "Average track duration"
+msgstr "Priemerná dĺžka skladby"
+
+#. Translators: the label for a setting in SPL add-on settings to include track artist count in playlist snapshots window.
+msgid "Artist count"
+msgstr "Interpreti"
+
+#. Translators: the label for a setting in SPL add-on settings to set top artist count limit in playlist snapshots window.
+msgid "Top artist count (0 displays all artists)"
+msgstr "Najhranejší interpreti (0 zobrazí všetkých interpretov)"
+
+#. Translators: the label for a setting in SPL add-on settings to include track category count in playlist snapshots window.
+msgid "Category count"
+msgstr "Kategórie"
+
+#. Translators: the label for a setting in SPL add-on settings to set top track category count limit in playlist snapshots window.
+msgid "Top category count (0 displays all categories)"
+msgstr "Najhranejšie kategórie (0 zobrazí všetky)"
+
+#. Translators: the label for a setting in SPL add-on settings to include track genre count in playlist snapshots window.
+msgid "Genre count"
+msgstr "žáner"
+
+#. Translators: the label for a setting in SPL add-on settings to set top track genre count limit in playlist snapshots window.
+msgid "Top genre count (0 displays all genres)"
+msgstr "Najhranejší žáner (0 zobrazí všetky)"
+
+#. Translators: the label for a setting in SPL add-on settings to show playlist snaphsots window when the snapshots command is pressed once.
+msgid "&Show results window when playlist snapshots command is performed once"
+msgstr "Pri prvom &stlačení skratky rovno zobraziť okno so štatistikou"
+
+#. Translators: Title of a dialog to configure metadata streaming status for DSP encoder and four additional URL's.
+msgid "Metadata streaming options"
+msgstr "Nastavenia metadát streamu"
+
+msgid "Select the URL for metadata streaming upon request."
+msgstr "Vyberte url na streamovanie metadát."
+
+msgid "Check to enable metadata streaming, uncheck to disable."
+msgstr ""
+"Začiarknite, ak chcete povoliť vysielanie metadát, odčiarknite, ak chcete "
+"vysielanie zakázať."
+
+msgid "&Stream:"
+msgstr "&Stream:"
+
+#. Translators: A checkbox to let metadata streaming status be applied to the currently active broadcast profile.
+msgid "&Apply streaming changes to the selected profile"
+msgstr "&Použiť nastavenia vo vybratom profile"
+
+#. Translators: title of a panel to configure metadata streaming status for DSP encoder and four additional URL's.
+msgid "Metadata streaming"
+msgstr "Vysielanie metadát"
+
+#. Translators: One of the metadata notification settings.
+msgid "When Studio starts"
+msgstr "Po štarte SPL"
+
+#. Translators: One of the metadata notification settings.
+msgid "When instant switch profile is active"
+msgstr "Po ručnej aktivácii profilu"
+
+#. Translators: the label for a setting in SPL add-on settings to be notified that metadata streaming is enabled.
+msgid "&Metadata streaming notification and connection"
+msgstr "Upozornenia a vysielanie &Metadát"
+
+#. WX's native CheckListBox isn't user friendly.
+#. Therefore use checkboxes laid out across the top.
+#. 17.04: instead of two loops, just use one loop, with labels deriving from a stream labels tuple.
+#. Only one loop is needed as helper.addLabelControl returns the checkbox itself and that can be appended.
+#. Add checkboxes for each stream, beginning with the DSP encoder.
+#. #76 (18.09-LTS): completely changed to use custom check list box (NVDA Core issue 7491).
+msgid "&Select the URL for metadata streaming upon request:"
+msgstr "&Vyberte url na vysielanie metadát."
+
+#. Translators: title of a panel to configure column announcements (order and what columns should be announced).
+msgid "Column announcements"
+msgstr "Oznamovanie metadát"
+
+#. Translators: the label for a setting in SPL add-on settings to toggle custom column announcement.
+msgid "Announce columns in the &order shown on screen"
+msgstr "&Oznamovať metadáta v poradí ako na obrazovke"
+
+#. Translators: Help text to select columns to be announced.
+msgid ""
+"&Select columns to be announced\n"
+"(artist and title are announced by default):"
+msgstr ""
+"&Vyberte metadáta, ktoré chcete oznamovať\n"
+"(Predvolene sú oznamované interpret a názov skladby):"
+
+#. wxPython 4 contains RearrangeList to allow item orders to be changed automatically.
+#. Because wxPython 3 doesn't include this, work around by using a variant of list box and move up/down buttons.
+#. 17.04: The label for the list below is above the list, so move move up/down buttons to the right of the list box.
+#. Translators: The label for a setting in SPL add-on dialog to select column announcement order.
+msgid "Column &order:"
+msgstr "P&oradie metadát:"
+
+#. Translators: The label for a button in column announcement dialog to change column position for the selected column.
+msgid "Move &up"
+msgstr "Posunúť &hore"
+
+#. Translators: The label for a button in column announcement dialog to change column position for the selected column.
+msgid "Move &down"
+msgstr "Posunúť &dole"
+
+#. Translators: the label for a setting in SPL add-on settings to toggle whether column headers should be included when announcing track information.
+msgid "Include column &headers when announcing track information"
+msgstr "Pri oznamovaní informácií o skladbe zahrnúť &Metadáta"
+
+#. Translators: Title of a panel to configure playlsit transcripts options.
+msgid "Playlist transcripts"
+msgstr "Prepisy playlistu"
+
+#. Translators: Help text to select columns to be announced.
+msgid ""
+"&Select columns to be included in playlist transcripts\n"
+"(artist and title are always included):"
+msgstr ""
+"Vyberte metadáta, ktoré sa objavia v prepise playlistu.\n"
+"(Interpret a názov skladby budú zahrnuté vždy):"
+
+#. Translators: title of a panel to configure columns explorer settings.
+msgid "Columns explorer"
+msgstr "Prehliadač metadát"
+
+#. Translators: The label of a button to configure columns explorer slots (SPL Assistant, number row keys to announce specific columns).
+msgid "Columns E&xplorer..."
+msgstr "Prehliadač &metadát..."
+
+#. Translators: The label of a button to configure columns explorer slots for Track Tool (SPL Assistant, number row keys to announce specific columns).
+msgid "Columns Explorer for &Track Tool..."
+msgstr "Prehliadač me&tadát pre nástroj skladieb..."
+
+#. Translators: The label of a button to configure columns explorer slots (SPL Assistant, number row keys to announce specific columns).
+msgid "Columns Explorer for &SPL Creator..."
+msgstr "Prehliadač metadát pre &SPL creator..."
+
+#. Translators: The title of Columns Explorer configuration dialog.
+msgid "Columns Explorer"
+msgstr "Prehliadač metadát"
+
+#. Translators: The title of Columns Explorer configuration dialog.
+msgid "Columns Explorer for Track Tool"
+msgstr "Prehladač metadát pre nástroj skladieb"
+
+#. Translators: The title of Columns Explorer configuration dialog.
+msgid "Columns Explorer for SPL Creator"
+msgstr "Prehliadač metadát pre SPL Creator"
+
+#. Translators: The label for a setting in SPL add-on dialog to select column for this column slot.
+#, python-brace-format
+msgid "Slot {position}"
+msgstr "Slot {position}"
+
+#. Translators: title of a panel to configure various status announcements such as announcing listener count.
+msgid "Status announcements"
+msgstr "Oznamovanie stavu"
+
+#. Translators: the label for a setting in SPL add-on settings to announce scheduled time.
+msgid "Announce &scheduled time for the selected track"
+msgstr "Oznamovať plánovaný &čas odohratia nasledujúcej skladby"
+
+#. Translators: the label for a setting in SPL add-on settings to announce listener count.
+msgid "Announce &listener count"
+msgstr "Oznamovať &Počet poslucháčov"
+
+#. Translators: the label for a setting in SPL add-on settings to announce currently playing cart.
+msgid "&Announce name of the currently playing cart"
+msgstr "Oznamovať názov prehrávaného &jingla"
+
+#. Translators: the label for a setting in SPL add-on settings to announce currently playing track name.
+msgid "&Track name announcement:"
+msgstr "Oznamovanie názvu &Skladby:"
+
+#. Translators: One of the track name announcement options.
+msgid "automatic"
+msgstr "Automaticky"
+
+#. Translators: One of the track name announcement options.
+msgid "while using other programs"
+msgstr "Keď je aktívne iné okno"
+
+#. Translators: One of the track name announcement options.
+msgid "off"
+msgstr "vypnuté"
+
+#. Translators: the label for a setting in SPL add-on settings to announce player position for the current and next tracks.
+msgid ""
+"Include track player &position when announcing current and next track "
+"information"
+msgstr ""
+"Oznamovať aktuálnu pozíciu pri oznamovaní &aktuálnej a nasledujúcej skladby"
+
+#. Translators: title of a panel to configure advanced SPL add-on options such as update checking.
+msgid "Advanced"
+msgstr "pokročilé"
+
+#. Translators: A checkbox to toggle if SPL Controller command can be used to invoke Assistant layer.
+msgid "Allow SPL C&ontroller command to invoke SPL Assistant layer"
+msgstr "Povoliť aktiváciu &SPL asistenta z kontroléra"
+
+#. Translators: The label for a setting in SPL add-on dialog to set keyboard layout for SPL Assistant.
+msgid "SPL Assistant command &layout:"
+msgstr "&Rozloženie príkazov:"
+
+#. 18.09: allow some dev snapshot users to test pilot features.
+#. Translators: A checkbox to enable pilot features (with risks involved).
+msgid ""
+"Pilot features: I want to test and provide early &feedback on features under "
+"development"
+msgstr ""
+"&Testovanie: chcem testovať nové funkcie doplnku pred oficiálnym vydaním"
+
+#. Translators: The confirmation prompt displayed when about to enable pilot flag (with risks involved).
+msgid ""
+"You are about to enable pilot features. Please note that pilot features may "
+"include functionality that might be unstable at times and should be used for "
+"testing and sending feedback to the add-on developer. If you prefer to use "
+"stable features, please answer no and uncheck pilot features checkbox. Are "
+"you sure you wish to enable pilot features?"
+msgstr ""
+"Chystáte sa aktivovať testovanie nových funkcií. Upozorňujeme, že sa k vám "
+"môžu dostať aj verzie doplnku, ktoré nebudú stabilné. Môžete nám hlásiť, čo "
+"nefunguje a prispieť tak k zlepšeniu doplnku. Ak nechcete testovať nové "
+"funkcie, odpovedzte nie a odčiarknite funkciu testovanie. Naozaj chcete "
+"testovať nové funkcie?"
+
+#. Translators: The title of the channel switch confirmation dialog.
+msgid "Enable pilot features"
+msgstr "Povoliť testovanie"
+
+#. Translators: A dialog message shown when pilot features is turned on or off.
+msgid ""
+"You have toggled pilot features checkbox. You must restart NVDA for the "
+"change to take effect."
+msgstr ""
+"Zmenili ste nastavenie funkcie testovanie. Zmeny sa prejavia po reštarte."
+
+#. Translators: Title of the pilot features dialog.
+msgid "Pilot features"
+msgstr "Testovanie"
+
+#. Translators: Title of the dialog to reset various add-on settings.
+#. Translators: title of a panel to reset add-on settings.
+msgid "Reset settings"
+msgstr "Obnovenie nastavení"
+
+#. Translators: the label for resetting profile triggers.
+msgid "Reset instant switch profile"
+msgstr "Obnoviť profil s ručnou aktiváciou"
+
+#. Translators: the label for resetting profile triggers.
+msgid "Delete time-based profile database"
+msgstr "Vymazať časovo aktivované profily"
+
+#. Translators: the label for resetting encoder settings.
+msgid "Remove encoder settings"
+msgstr "Vymazať nastavenia enkodéra"
+
+#. Translators: the label for resetting track comments.
+msgid "Erase track comments"
+msgstr "Vymazať komentáre k skladbám"
+
+#. Translators: A message to warn about resetting SPL config settings to factory defaults.
+msgid "Are you sure you wish to reset SPL add-on settings to defaults?"
+msgstr "Naozaj chcete obnoviť nastavenia doplnku SPL?"
+
+#. Translators: The title of the warning dialog.
+msgid "Warning"
+msgstr "Potvrdenie"
+
+#. Translators: A dialog message shown when settings were reset to defaults.
+msgid "Successfully applied default add-on settings."
+msgstr "Nastavenia boli obnovené."
+
+#. Translators: Title of the reset config dialog.
+msgid "Reset configuration"
+msgstr "Obnovenie nastavení"
+
+#. Translators: Help text explaijning what will happen when settings are reset.
+msgid ""
+"Warning! Selecting Reset button and choosing various reset options will "
+"reset add-on settings to defaults."
+msgstr ""
+"Upozornenie! Aktivovaním tlačidla obnova nastavení a začiarknutím "
+"príslušných začiarkávacích políčok vynulujete nastavenia doplnku."
+
+#. Translators: The label of a button to open reset dialog.
+msgid "Reset settings..."
+msgstr "Obnoviť nastavenia..."
+
+#. Translators: This is the label for the StationPlaylist add-on configuration dialog.
+msgid "StationPlaylist Add-on Settings"
+msgstr "Nastavenia doplnku Station playllist"
+
+#. Translators: Presented when an alarm dialog is opened.
+msgid ""
+"Another add-on settings dialog is open. Please close the previously opened "
+"dialog first."
+msgstr ""
+"Máte otvorené iné okno s nastaveniami doplnku SPL. Prosím, najskôr ho "
+"zatvorte."
+
+#. Translators: Text of the dialog when another find dialog is open.
+msgid "Another find dialog is open."
+msgstr "Máte otvorené iné okno hľadania."
+
+#. Translators: Text of the dialog when a generic error has occured.
+msgid "An unexpected error has occured when trying to open find dialog."
+msgstr "Pri pokuse otvoriť okno s vyhľadávaním nastala nečakaná chyba."
+
+msgid "Enter or select the name or the artist of the track you wish to &search"
+msgstr "zadajte alebo vyberte názov skladby alebo interpreta, ktorého hľadáte"
+
+msgid "Enter or select text to be &searched in a column"
+msgstr "Napíšte, čo &Hľadáte"
+
+#. Translators: The label in track finder to search columns.
+msgid "C&olumn to search:"
+msgstr "Prehľadať &Metadáta:"
+
+#. Translators: The title of a dialog to find tracks with duration within a specified range.
+msgid "Time range finder"
+msgstr "Vyhľadanie podľa času"
+
+msgid "Minimum duration"
+msgstr "Minimálna dĺžka"
+
+msgid "Second"
+msgstr "sekunda"
+
+msgid "Maximum duration"
+msgstr "Maximálna dĺžka"
+
+#. Translators: Message to report wrong value for duration fields.
+msgid "Minimum duration is greater than the maximum duration."
+msgstr "Minimálna dĺžka je väčšia ako maximálna dĺžka."
+
+#. Translators: Standard dialog message when an item one wishes to search is not found (copy this from main nvda.po).
+msgid "No track with duration between minimum and maximum duration."
+msgstr "Zadaným krytériám nevyhovuje žiadna skladba."
+
+#. Translators: Standard error title for find error (copy this from main nvda.po).
+msgid "Time range find error"
+msgstr "Chyba"
+
+msgid "Countdown started"
+msgstr "Odpočítavam"
+
+msgid "Timer complete"
+msgstr "Odpočítavanie dokončené"
+
+#. Translators: presented when metadata streaming status cannot be obtained.
+msgid "Cannot obtain metadata streaming status information"
+msgstr "Nepodarilo sa získať informácie o metadátach živého vysielania"
+
+#. Translators: Status message for metadata streaming.
+msgid "No metadata streaming URL's defined"
+msgstr "Nie sú definované žiadne URL pre metadáta živého vysielania"
+
+#. Translators: Status message for metadata streaming.
+msgid "Metadata streaming configured for DSP encoder"
+msgstr "Metadáta nastavené pre DSP enkodér"
+
+#. Translators: Status message for metadata streaming.
+#, python-brace-format
+msgid "Metadata streaming configured for DSP encoder and URL {URL}"
+msgstr "Metadáta nastavené pre DSP enkodér a URL {URL}"
+
+#. Translators: Status message for metadata streaming.
+#, python-brace-format
+msgid "Metadata streaming configured for URL {URL}"
+msgstr "Metadáta nastavené pre URL {URL}"
+
+#. Translators: Status message for metadata streaming.
+#, python-brace-format
+msgid "Metadata streaming configured for DSP encoder and URL's {URL}"
+msgstr "Metadata nastavené pre DSP enkodér a adresy {URL}"
+
+#. Translators: Status message for metadata streaming.
+#, python-brace-format
+msgid "Metadata streaming configured for URL's {URL}"
+msgstr "Metadáta nastavené pre adresy {URL}"
+
+#. Translators: the Playlist transcripts dialog title.
+msgid "Playlist Transcripts"
+msgstr "Prepisy playlistu"
+
+msgid "Playlist data copied to clipboard"
+msgstr "Skopírované do schránky"
+
+#. Translators: Text of the dialog when another playlist transcripts dialog is open.
+msgid "Another playlist transcripts dialog is open."
+msgstr "Máte otvorené iné okno s prepisom playlistu."
+
+#. Translators: one of the playlist transcripts range options.
+msgid "entire playlist"
+msgstr "Celý playlist"
+
+#. Translators: one of the playlist transcripts range options.
+msgid "start to current item"
+msgstr "Od začiatku Po aktuálnu položku"
+
+#. Translators: one of the playlist transcripts range options.
+msgid "current item to the end"
+msgstr "Od aktuálnej položky na koniec"
+
+#. Translators: one of the playlist transcripts range options.
+msgid "current hour"
+msgstr "Aktuálna hodina"
+
+#. Translators: The label in playlist transcripts dialog to select playlist transcript range.
+msgid "Transcript range:"
+msgstr "Rozsah prepisu:"
+
+#. Translators: The label in playlist transcripts dialog to select transcript output format.
+msgid "Transcript format:"
+msgstr "Formát prepisu:"
+
+#. Translators: one of the playlist transcript actions.
+msgid "view transcript"
+msgstr "Zobraziť prepis"
+
+#. Translators: one of the playlist transcript actions.
+msgid "copy to clipboard"
+msgstr "Skopírovať do schránky"
+
+#. Translators: one of the playlist transcript actions.
+msgid "save to file"
+msgstr "Uložiť do súboru"
+
+#. Translators: The label in playlist transcripts dialog to select transcript action.
+msgid "Transcript action:"
+msgstr "Akcia:"
+
+#. Help message for SPL Controller
+#. Translators: the dialog text for SPL Controller help.
+msgid ""
+"\n"
+"After entering SPL Controller, press:\n"
+"A: Turn automation on.\n"
+"Shift+A: Turn automation off.\n"
+"M: Turn microphone on.\n"
+"Shift+M: Turn microphone off.\n"
+"N: Turn microphone on without fade.\n"
+"L: Turn line in on.\n"
+"Shift+L: Turn line in off.\n"
+"P: Play.\n"
+"U: Pause.\n"
+"S: Stop with fade.\n"
+"T: Instant stop.\n"
+"C: Announce name and duration of the currently playing track.\n"
+"E: Announce connected encoders if any.\n"
+"I: Announce listener count.\n"
+"Q: Announce Studio status information.\n"
+"R: Remaining time for the playing track.\n"
+"Shift+R: Library scan progress.\n"
+"Function keys and number row keys with or without Shift, Alt, and Control "
+"keys: Play carts."
+msgstr ""
+"\n"
+"V SPL kontroléry máte tieto možnosti:\n"
+"A: Zapnúť autopylota.\n"
+"Shift+A: Vypnúť autopylota.\n"
+"M: Zapnúť mikrofón.\n"
+"Shift+M: Vypnúť mikrofón.\n"
+"N: Zapnúť mikrofón bez stíšenia.\n"
+"L: Zapnúť line-in.\n"
+"Shift+L: Vypnúť Line-in.\n"
+"P: Prehrať.\n"
+"U: pauza.\n"
+"S: Stíšiť a zastaviť.\n"
+"T: Okamžite zastaviť.\n"
+"C: Oznám názov a dĺžku hrajúcej skladby.\n"
+"E: Oznám pripojené enkodéry.\n"
+"I: Oznám počet poslucháčov.\n"
+"Q: Oznám stav štúdia.\n"
+"R: Oznám zostávajúci čas do konca skladby.\n"
+"Shift+R: Oznám stav skenovania knižnice.\n"
+"Funkčné klávesy a klávesy v hornom rade čísel so a bez shiftu a v kombinácii "
+"s klávesmi alt a ctrl: Prehrávať jingle."
+
+#. Translators: Presented when StationPlaylist Studio is not running.
 msgid "SPL Studio is not running."
 msgstr "SPL studio nie je spustený."
 
-#. Translators: Presented when Studio is minimized to system tray (notification area).
-msgid "SPL minimized to system tray."
-msgstr "SPL je minimalizovaný na systémovej lište."
-
-#. Translators: Input help mode message for a command to switch to Station Playlist Studio from any program.
+#. Translators: Input help mode message for a command to switch to StationPlaylist Studio from any program.
 msgid "Moves to SPL Studio window from other programs."
 msgstr "Presunie fokus do okna SPL Studio."
 
@@ -184,88 +1883,206 @@ msgid ""
 msgstr ""
 "Okno SPL Studio je aktívne. Pre zistenie stavu použite príkazy SPL asistenta."
 
-#. Translators: The name of a layer command set for Station Playlist Studio.
+#. Translators: The name of a layer command set for StationPlaylist add-on.
 #. Hint: it is better to translate it as "SPL Control Panel."
 msgid "SPL Controller"
 msgstr "ovládanie"
 
-#. Translators: Input help mode message for a layer command in Station Playlist Studio.
+#. Translators: Input help mode message for a layer command in StationPlaylist add-on.
 msgid "SPl Controller layer command. See add-on guide for available commands."
 msgstr "podmnožina na ovládanie SPL.. Podrobnosti nájdete v návode k doplnku."
 
-#. Translators: Presented when no track is playing in Station Playlist Studio.
+#. Translators: Presented when no track is playing in StationPlaylist Studio.
 msgid "There is no track playing. Try pausing while a track is playing."
 msgstr "Nie je spustená žiadna skladba. Ak skladba hrá, skúste ju pozastaviť."
 
-#. Translators: Presented when no track is playing in Station Playlist Studio.
+#. Translators: Announces number of items in the Studio's track library (example: 1000 items scanned).
+#, python-brace-format
+msgid "Scan in progress with {itemCount} items scanned"
+msgstr "Prebieha skenovanie {itemCount} naskenovaných položiek"
+
+#. Translators: Announces number of items in the Studio's track library (example: 1000 items scanned).
+#, python-brace-format
+msgid "Scan complete with {itemCount} items scanned"
+msgstr "Skenovanie dokončené, {itemCount} naskenovaných položiek"
+
+#. Translators: Announces number of stream listeners.
+#, python-brace-format
+msgid "Listener count: {listenerCount}"
+msgstr "Práve počúva: {listenerCount}"
+
+#. Translators: Presented when no track is playing in StationPlaylist Studio.
 msgid "There is no track playing."
 msgstr "Nie je spustená žiadna skladba"
 
-#. Translators: Presented when SAM Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "pripájam..."
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "Nepodarilo sa získať informácie o metadátach živého vysielania"
 
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Connects to a streaming server."
-msgstr "pripojí na vysielací server."
+#. Translators: Input help message for a SPL Controller command.
+msgid "Announces stream encoder status from other programs"
+msgstr "Oznamuje stav enkodérov ak je v popredí okno inej aplikácie"
 
-#. Translators: Presented when SAM Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "odpájam..."
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Disconnects from a streaming server."
-msgstr "Odpojí z vysielacieho servera."
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "prepnúť do štúdia po pripojení"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "neprepojiť do štúdia po pripojení"
-
-#. Translators: Input help mode message in SAM Encoder window.
+#. Translators: Input help message for a SPL Controller command.
 msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr "určuje, či sa NVDA vráti do okna štúdia po pripojení na server."
+"Announces Studio status such as track playback status from other programs"
+msgstr ""
+"Oznamuje stav štúdia (napríklad prehrávanie) ak je v popredí okno inej "
+"aplikácie."
 
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "prehrať prvú skladbu po pripojení"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "neprehrať pvú skladbu po pripojení"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr "určuje, či SPL prehráv prvú skaldbu po pripojení na vysielací server."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-msgid "Stream labeler for {streamEntry}"
-msgstr "označenie vysielania pre {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "zadajte názov tohto vysielania"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "otvorí dialóg, v ktorom môžete pomenovať nastavenie enkodéra."
+#. Translators: The title for SPL Controller help dialog.
+msgid "SPL Controller help"
+msgstr "Pomocník pre spl kontrolér"
 
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
-"Enhances support for Station Playlist Studio.\n"
+"Enhances support for StationPlaylist Studio.\n"
 "In addition, adds global commands for the studio from everywhere."
 msgstr ""
 "Zlepšuje prístupnosť programu Station Playlist.\n"
 "Navyše pridáva globálne skratky, ktoré sa dajú použiť aj mimo hlavného okna "
 "SPL."
 
-#~ msgid "Press Alt+Tab to switch to SPL Studio window"
-#~ msgstr "na prechod do okna SPL Studio stlačte alt+tab"
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr "Je otvorený dialóg s nastaveniami doplnku. Najprv ho zatvorte."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Nepodarilo sa zistiť informácie o práve hrajúcej skladbe, alebo žiadna "
+#~ "skladba nehrá"
+
+#~ msgid "No encoders found"
+#~ msgstr "Žiadne enkodéry"
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr "Naraz môžete mať aktivovaný len jeden typ enkodéra"
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Pripojené enkodéry: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Žiadne pripojené enkodéry"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Nastavenie enkodéra pre {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Názov streamu"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&prepnúť do štúdia po pripojení"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "p&rehrať prvú skladbu po pripojení"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Povoliť pripojenie a monitorovanie na pozadí"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "&Pípať počas pripájania na server"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "prepnúť do štúdia po pripojení"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "neprepojiť do štúdia po pripojení"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr "určuje, či sa NVDA vráti do okna štúdia po pripojení na server."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "prehrať prvú skladbu po pripojení"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "neprehrať pvú skladbu po pripojení"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "určuje, či SPL prehráv prvú skaldbu po pripojení na vysielací server."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Sledovanie enkodéru {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Enkodér {encoderNumber} nebude sledovaný"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Sledovanie enkodéru vypnuté"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Určuje, či bude NVDA sledovať stav enkodéra na pozadí."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "označenie vysielania pre {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "zadajte názov tohto vysielania"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "otvorí dialóg, v ktorom môžete pomenovať nastavenie enkodéra."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Odstránenie dát streamu a enkodéra"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "Zadajte číslo enkodéra na odstránenie"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "otvorí dialóg, v ktorom môžete odstrániť informácie o streame z "
+#~ "odstráneného enkodéra."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Máte otvorené iné okno s nastaveniami enkodéra."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Zobrazí dialóg s nastaveniami enkodéra, kde môžete nastaviť napríklad "
+#~ "názov streamu"
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Oznámy aktuálny čas vrátane sekúnd. Stlačené dvakrát rýchlo za sebou "
+#~ "oznámy dátum."
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Pozícia: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Názov: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Žiadny názov streamu"
+
+#~ msgid "Connecting..."
+#~ msgstr "pripájam..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "odpájam..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "pripojí na vysielací server."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Nastavenia enkodéra: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Prenosová rýchlosť: {transferRate}"

--- a/addon/locale/sr/LC_MESSAGES/nvda.po
+++ b/addon/locale/sr/LC_MESSAGES/nvda.po
@@ -28,6 +28,15 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Otkrivena je starija verzija Windowsa"
 
+#. Translators: Title of the column data window.
+#, fuzzy
+msgid "Track data"
+msgstr "Uvodni zapis"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr ""
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Mikrofon aktivan"
@@ -58,14 +67,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist Studio"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr ""
-
-#. Translators: Title of the column data window.
-#, fuzzy
-msgid "Track data"
-msgstr "Uvodni zapis"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -100,10 +109,6 @@ msgstr "{checkStatus}{header}: prazno"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr ""
 
 msgid "Has comment"
 msgstr "Ima komentar"
@@ -405,11 +410,13 @@ msgid "Announces time including seconds."
 msgstr "Izgovara vreme uključujući sekunde"
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
 msgstr ""
-"Dijalog za podešavanja dodatka je otvoren. Molimo prvo zatvorite dijalog za "
-"podešavanja"
+"Dijalog sa podešavanjima dodatka ili metadata stream dijalog je već otvoren. "
+"Molimo prvo zatvorite dijalog"
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -694,7 +701,14 @@ msgid "Playlist modification not available"
 msgstr "Izmena liste za reprodukciju nije dostupna"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Nijedan zapis se ne reprodukuje"
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr "Nema sledećeg podešenog zapisa ili se zapis ne reprodukuje"
 
 #. Translators: Presented when next track information is unavailable.
@@ -706,10 +720,9 @@ msgid "Announces title of the next track if any"
 msgstr "Izgovara naslov sledećeg zapisa ako postoji"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Nemoguće pronaći informacije o trenutnom zapisu ili se nijedan zapis ne "
-"reprodukuje"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Nemoguće pronaći informacije trenutnog zapisa"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -785,6 +798,10 @@ msgstr ""
 "Prikazuje informacije statistike liste za reprodukciju kao što su broj "
 "zapisa i izvođači na vrhu"
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr "Dijalog za podešavanja dodatka je otvoren, nemoguće promeniti profile"
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "Nijedan zapis nije pronađen, nemoguće podesiti početni marker"
@@ -855,10 +872,6 @@ msgstr ""
 #, fuzzy
 msgid "SPL Studio add-on reset"
 msgstr "Podešavanja Studio dodatka"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr "Dijalog za podešavanja dodatka je otvoren, nemoguće promeniti profile"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1952,6 +1965,11 @@ msgstr "Broj slušaoca: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Nijedan zapis se ne reprodukuje"
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "Nemoguće otvoriti metadata dijalog strima"
+
 #. Translators: Input help message for a SPL Controller command.
 #, fuzzy
 msgid "Announces stream encoder status from other programs"
@@ -1970,182 +1988,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Pomoć za SPL kontroler"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-#, fuzzy
-msgid "No encoders found"
-msgstr "Marker nije pronađen"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr ""
-
-#. Translators: presented when at least one encoder is connected.
-#, fuzzy, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Gledanje enkodera{encoderNumber}"
-
-#. Translators: presented when no encoders are connected.
-#, fuzzy
-msgid "No encoders connected"
-msgstr "Nijedan enkoder se ne gleda"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Podešavanja enkodera za{name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "&Oznaka strima"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "&Fokusiraj se na Studio nakon povezivanja"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Reprodukuj prvi zapis nakon povezivanja"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "&Omogući povezivanje i gledanje u pozadini"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "&Reprodukuj pištanja statusa povezivanja u toku povezivanja"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Prebaci se na Studio nakon povezivanja"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Ne prebacuj se na Studio nakon povezivanja"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Odlučuje da li NVDA treba da se prebaci na Studio kada se povežete na server "
-"za strimovanje"
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Reprodukuj prvi zapis nakon povezivanja"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Ne reprodukuj prvi zapis nakon povezivanja"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr "Odlučuje da li će Studio reprodukovati prvi zapis nakon povezivanja"
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Gledanje enkodera{encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Enkoder{encoderNumber} neće biti gledan"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Gledanje enkodera obustavljeno"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "Odlučuje da li će NVDA pratiti izabran enkoder u pozadini"
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Oznaka strima za{streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Upišite oznaku za ovaj strim"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Otvara dijalog za oznaku izabranog enkodera"
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Brisač podešavanja i oznaka strimova"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "Upišite poziciju enkodera koji želite da obrišete"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr "Otvara dijalog za brisanje oznake strimova za određen enkoder"
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Drugi dijalog sa podešavanjima enkodera je otvoren."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Prikazuje dijalog za podešavanje različitih podešavanja enkodera kao što su "
-"oznaka strima"
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Ako se pritisne jednom, prijavljuje trenutno vreme uključujući sekunde. Ako "
-"se pritisne dva puta, prijavljuje datum"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Pozicija: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Oznaka: {label}"
-
-msgid "No stream label"
-msgstr "Nema oznake strima"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Povezivanje..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Prekidanje veze..."
-
-msgid "Connects to a streaming server."
-msgstr "Povezuje se na server za strimovanje"
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Podešavanja enkodera: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Brzina: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2154,3 +1996,146 @@ msgid ""
 msgstr ""
 "Poboljšava podršku za StationPlaylist Studio.\n"
 "Takođe, dodaje globalne komande za studio bilo gde."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr ""
+#~ "Dijalog za podešavanja dodatka je otvoren. Molimo prvo zatvorite dijalog "
+#~ "za podešavanja"
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Nemoguće pronaći informacije o trenutnom zapisu ili se nijedan zapis ne "
+#~ "reprodukuje"
+
+#, fuzzy
+#~ msgid "No encoders found"
+#~ msgstr "Marker nije pronađen"
+
+#, fuzzy
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Gledanje enkodera{encoderNumber}"
+
+#, fuzzy
+#~ msgid "No encoders connected"
+#~ msgstr "Nijedan enkoder se ne gleda"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Podešavanja enkodera za{name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Oznaka strima"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&Fokusiraj se na Studio nakon povezivanja"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Reprodukuj prvi zapis nakon povezivanja"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "&Omogući povezivanje i gledanje u pozadini"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "&Reprodukuj pištanja statusa povezivanja u toku povezivanja"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Prebaci se na Studio nakon povezivanja"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Ne prebacuj se na Studio nakon povezivanja"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Odlučuje da li NVDA treba da se prebaci na Studio kada se povežete na "
+#~ "server za strimovanje"
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Reprodukuj prvi zapis nakon povezivanja"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Ne reprodukuj prvi zapis nakon povezivanja"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr "Odlučuje da li će Studio reprodukovati prvi zapis nakon povezivanja"
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Gledanje enkodera{encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Enkoder{encoderNumber} neće biti gledan"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Gledanje enkodera obustavljeno"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Odlučuje da li će NVDA pratiti izabran enkoder u pozadini"
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Oznaka strima za{streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Upišite oznaku za ovaj strim"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Otvara dijalog za oznaku izabranog enkodera"
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Brisač podešavanja i oznaka strimova"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "Upišite poziciju enkodera koji želite da obrišete"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr "Otvara dijalog za brisanje oznake strimova za određen enkoder"
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Drugi dijalog sa podešavanjima enkodera je otvoren."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Prikazuje dijalog za podešavanje različitih podešavanja enkodera kao što "
+#~ "su oznaka strima"
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Ako se pritisne jednom, prijavljuje trenutno vreme uključujući sekunde. "
+#~ "Ako se pritisne dva puta, prijavljuje datum"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Pozicija: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Oznaka: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Nema oznake strima"
+
+#~ msgid "Connecting..."
+#~ msgstr "Povezivanje..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Prekidanje veze..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Povezuje se na server za strimovanje"
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Podešavanja enkodera: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Brzina: {transferRate}"

--- a/addon/locale/vi/LC_MESSAGES/nvda.po
+++ b/addon/locale/vi/LC_MESSAGES/nvda.po
@@ -28,6 +28,14 @@ msgstr ""
 msgid "Old Windows version"
 msgstr "Phiên bản Windows cũ"
 
+#. Translators: Title of the column data window.
+msgid "Track data"
+msgstr "Dữ liệu track"
+
+#. Translators: input help mode message for columns viewer command.
+msgid "Presents data for all columns in the currently selected track"
+msgstr "Trình bày tất cả các cột dữ liệu cho track đang được chọn"
+
 #. Translators: Presented when microphone has been active for a while.
 msgid "Microphone active"
 msgstr "Microphone hoạt động"
@@ -59,13 +67,14 @@ msgstr ""
 msgid "StationPlaylist"
 msgstr "StationPlaylist"
 
+#. Translators: Presented when column is out of range.
+#, python-brace-format
+msgid "Column {columnPosition} not found"
+msgstr ""
+
 #. Translators: presented when column information for a track is empty.
 msgid "blank"
 msgstr "rỗng"
-
-#. Translators: Title of the column data window.
-msgid "Track data"
-msgstr "Dữ liệu track"
 
 #. Translators: Presented when a specific column header is not found.
 #, python-brace-format
@@ -100,10 +109,6 @@ msgstr "{checkStatus}{header}: rỗng"
 #, python-brace-format
 msgid "{checkStatus}{header}: ()"
 msgstr "{checkStatus}{header}: ()"
-
-#. Translators: input help mode message for columns viewer command.
-msgid "Presents data for all columns in the currently selected track"
-msgstr "Trình bày tất cả các cột dữ liệu cho track đang được chọn"
 
 msgid "Has comment"
 msgstr "Có chú thích"
@@ -411,9 +416,13 @@ msgid "Announces time including seconds."
 msgstr "Thông báo thời gian bao bồm giây."
 
 #. Translators: Presented when the add-on config dialog is opened.
+#, fuzzy
 msgid ""
-"The add-on settings dialog is opened. Please close the settings dialog first."
-msgstr "Hộp thoại cài đặt add-on đang mở. Vui lòng đóng nó lại trước."
+"The add-on settings dialog or another alarm dialog is opened. Please close "
+"the opened dialog first."
+msgstr ""
+"Hộp thoại cài đặt add-on hoặc hộp thoại truyền siêu dữ liệu đang mở. Vui "
+"lòng đóng chúng lại trước."
 
 #. Translators: Input help mode message for a command in StationPlaylist add-on.
 msgid "Sets end of track alarm (default is 5 seconds)."
@@ -693,7 +702,14 @@ msgid "Playlist modification not available"
 msgstr "Sửa đổi danh sách phát không sẵn sàng"
 
 #. Translators: Presented when there is no information for the next track.
-msgid "No next track scheduled or no track is playing"
+#. Translators: Presented when there is no information for the current track.
+#, fuzzy
+msgid "No track is playing"
+msgstr "Không có track nào đang phát."
+
+#. Translators: Presented when there is no information for the next track.
+#, fuzzy
+msgid "No next track scheduled"
 msgstr ""
 "Không có track kế nào được lên lịch hoặc không có track nào đang được phát"
 
@@ -706,10 +722,9 @@ msgid "Announces title of the next track if any"
 msgstr "Thông báo tựa đề track kế tiếp nếu có"
 
 #. Translators: Presented when there is no information for the current track.
-msgid "Cannot locate current track information or no track is playing"
-msgstr ""
-"Không thể xem thông tin của track hiện tại hoặc không có track nào đang được "
-"phát"
+#, fuzzy
+msgid "Cannot locate current track information"
+msgstr "Không tìm thấy thông tin của track hiện tại"
 
 #. Translators: Presented when current track information is unavailable.
 msgid "Cannot find current track information"
@@ -786,6 +801,10 @@ msgstr ""
 "Trình bày thông tin ảnh chụp danh sách phát như số track và các ca sĩ tiêu "
 "biểu"
 
+#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
+msgid "Add-on settings dialog is open, cannot switch profiles"
+msgstr "Hộp thoại cài đặt add-on đang mở, không thể chuyển hồ sơ"
+
 #. Translators: Presented when place marker cannot be set.
 msgid "No tracks found, cannot set place marker"
 msgstr "Không có track nào. Không thể tạo điểm đánh dấu"
@@ -860,10 +879,6 @@ msgstr ""
 #. Translators: The title of the confirmation dialog for Studio add-on settings reset.
 msgid "SPL Studio add-on reset"
 msgstr "Khôi phục cài đặt SPL Studio add-on"
-
-#. Translators: Presented when trying to switch to an instant switch profile when add-on settings dialog is active.
-msgid "Add-on settings dialog is open, cannot switch profiles"
-msgstr "Hộp thoại cài đặt add-on đang mở, không thể chuyển hồ sơ"
 
 #. Translators: Presented when switch to instant switch profile was successful.
 #, python-brace-format
@@ -1927,6 +1942,11 @@ msgstr "Số người nghe: {listenerCount}"
 msgid "There is no track playing."
 msgstr "Không có track nào đang phát."
 
+#. Translators: presented if encoder connection status cannot be obtained.
+#, fuzzy
+msgid "Cannot obtain encoder connection status"
+msgstr "Không thể thu thập thông tin trạng thái truyền siêu dữ liệu"
+
 #. Translators: Input help message for a SPL Controller command.
 msgid "Announces stream encoder status from other programs"
 msgstr "Thông báo trạng thái mã hóa phát sóng từ các chương trình khác."
@@ -1942,184 +1962,6 @@ msgstr ""
 msgid "SPL Controller help"
 msgstr "Trợ giúp bộ điều khiển SPL"
 
-#. Translators: presented when no streaming encoders were found when trying to obtain connection status.
-msgid "No encoders found"
-msgstr "Không tìm thấy bộ mã hóa nào"
-
-#. Translators: presented when more than one encoder type is active when trying to obtain encoder connection status.
-msgid "Only one encoder type can be active at once"
-msgstr "Chỉ có thể kích hoạt một loại mã hóa cho một lần"
-
-#. Translators: presented when at least one encoder is connected.
-#, python-brace-format
-msgid "Connected encoders: {encodersConnected}"
-msgstr "Các bộ mã hóa đã kết nối: {encodersConnected}"
-
-#. Translators: presented when no encoders are connected.
-msgid "No encoders connected"
-msgstr "Không có bộ mã hóa nào được kết nối"
-
-#. Translators: The title of the encoder settings dialog (example: Encoder settings for SAM 1").
-#, python-brace-format
-msgid "Encoder settings for {name}"
-msgstr "Cài đặt mã hóa cho {name}"
-
-#. Translators: An edit field in encoder settings to set stream label for this encoder.
-msgid "Stream &label"
-msgstr "&Nhãn phát thanh"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should switch focus to Studio window when connected.
-msgid "&Focus to Studio when connected"
-msgstr "&Chuyển về Studio khi đã kết nối"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play the next track when connected.
-msgid "&Play first track when connected"
-msgstr "&Phát track đầu tiên khi kết nối"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should monitor the status of this encoder in the background.
-msgid "Enable background connection &monitoring"
-msgstr "Bật kết nối và theo dõi ngầ&m"
-
-#. Translators: A checkbox in encoder settings to set if NvDA should play connection progress tone.
-msgid "Play connection status &beep while connecting"
-msgstr "Phát trạng thái kết nối &beep trong khi kết nối"
-
-#. Translators: Status message for encoder monitoring.
-#, python-brace-format
-msgid "{encoder} {encoderNumber}: {status}"
-msgstr "{encoder} {encoderNumber}: {status}"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Switch to Studio after connecting"
-msgstr "Chuyển đến Studio sau khi kết nối"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not switch to Studio after connecting"
-msgstr "Không chuyển đến Studio sau khi kết nối"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will switch to Studio when connected to a streaming "
-"server."
-msgstr ""
-"Bật chế độ để NVDA sẽ chuyển đến Studio khi đã kết nối đến một máy chủ phát "
-"thanh."
-
-#. Translators: Presented when toggling the setting to play selected song when connected to a streaming server.
-msgid "Play first track after connecting"
-msgstr "Phát track đầu tiên sau khi kết nối"
-
-#. Translators: Presented when toggling the setting to switch to Studio when connected to a streaming server.
-msgid "Do not play first track after connecting"
-msgstr "Không phát track đầu tiên sau khi kết nối"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether Studio will play the first song when connected to a "
-"streaming server."
-msgstr ""
-"Bật chế độ để Studio sẽ phát bài nhạc đầu tiên khi kết nối vào máy chủ đang "
-"phát."
-
-#. Multiple encoders.
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Monitoring encoder {encoderNumber}"
-msgstr "Đang theo dõi bộ mã hóa {encoderNumber}"
-
-#. Translators: Presented when toggling the setting to monitor the selected encoder.
-#, python-brace-format
-msgid "Encoder {encoderNumber} will not be monitored"
-msgstr "Bộ mã hóa {encoderNumber} sẽ không được theo dõi"
-
-#. Translators: Announced when background encoder monitoring is canceled.
-msgid "Encoder monitoring canceled"
-msgstr "Đã hủy bỏ theo dõi bộ mã hóa"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Toggles whether NVDA will monitor the selected encoder in the background."
-msgstr "Bật / tắt chế độ ngầm theo dõi bộ mã hóa được chọn."
-
-#. Translators: The title of the stream labeler dialog (example: stream labeler for 1).
-#, python-brace-format
-msgid "Stream labeler for {streamEntry}"
-msgstr "Đặt nhãn phát cho {streamEntry}"
-
-#. Translators: The text of the stream labeler dialog.
-msgid "Enter the label for this stream"
-msgstr "Nhập nhãn cho đường này"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid "Opens a dialog to label the selected encoder."
-msgstr "Mở hộp thoại để gán nhãn cho bộ mã hóa được chọn."
-
-#. Translators: The title of the stream configuration eraser dialog.
-msgid "Stream label and settings eraser"
-msgstr "Nhãn phát thanh và xóa các cài đặt"
-
-#. Translators: The text of the stream configuration eraser dialog.
-msgid "Enter the position of the encoder you wish to delete or will delete"
-msgstr "Nhập vị trí của bộ mã hóa bạn muốn xóa hoặc sẽ xóa"
-
-#. Translators: Input help mode message in SAM Encoder window.
-msgid ""
-"Opens a dialog to erase stream labels and settings from an encoder that was "
-"deleted."
-msgstr ""
-"Mở một hộp thoại để xóa các nhãn phát và các thiết lạp từ một bộ mã hóa đã "
-"bị xóa."
-
-#. Translators: Text of the dialog when another alarm dialog is open.
-msgid "Another encoder settings dialog is open."
-msgstr "Một hộp thoại cài đặt mã hóa khác đang mở."
-
-#. Translators: Input help mode message for a command in StationPlaylist add-on.
-msgid ""
-"Shows encoder configuration dialog to configure various encoder settings "
-"such as stream label."
-msgstr ""
-"Hiển thị hộp thoại cấu hình mã hóa để cấu hình nhiều cài đặt mã hóa như nhãn "
-"phát trực tuyến."
-
-#. Translators: Input help mode message for report date and time command.
-msgid ""
-"If pressed once, reports the current time including seconds. If pressed "
-"twice, reports the current date"
-msgstr ""
-"Bấm một lần để thông báo thời gian hiện tại bao gồm giây. Bấm hai lần để "
-"thông báo ngày hiện tại"
-
-#, python-brace-format
-msgid "Position: {pos}"
-msgstr "Vị trí: {pos}"
-
-#, python-brace-format
-msgid "Label: {label}"
-msgstr "Nhãn: {label}"
-
-msgid "No stream label"
-msgstr "Không có nhãn phát thanh"
-
-#. Translators: Presented when an Encoder is trying to connect to a streaming server.
-msgid "Connecting..."
-msgstr "Đang kết nối..."
-
-#. Translators: Presented when an Encoder is disconnecting from a streaming server.
-msgid "Disconnecting..."
-msgstr "Đang ngắt kết nối..."
-
-msgid "Connects to a streaming server."
-msgstr "Kết nối với một máy chủ đang phát."
-
-#, python-brace-format
-msgid "Encoder Settings: {setting}"
-msgstr "Cài đặt mã hóa: {setting}"
-
-#, python-brace-format
-msgid "Transfer Rate: {transferRate}"
-msgstr "Tốc độ truyền tải: {transferRate}"
-
 #. Add-on description
 #. Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 msgid ""
@@ -2128,3 +1970,148 @@ msgid ""
 msgstr ""
 "Cải thiện hỗ trợ cho StationPlaylist Studio.\n"
 "Ngoài ra là thêm các lệnh toàn cục cho studio từ bất cứ đâu."
+
+#~ msgid ""
+#~ "The add-on settings dialog is opened. Please close the settings dialog "
+#~ "first."
+#~ msgstr "Hộp thoại cài đặt add-on đang mở. Vui lòng đóng nó lại trước."
+
+#~ msgid "Cannot locate current track information or no track is playing"
+#~ msgstr ""
+#~ "Không thể xem thông tin của track hiện tại hoặc không có track nào đang "
+#~ "được phát"
+
+#~ msgid "No encoders found"
+#~ msgstr "Không tìm thấy bộ mã hóa nào"
+
+#~ msgid "Only one encoder type can be active at once"
+#~ msgstr "Chỉ có thể kích hoạt một loại mã hóa cho một lần"
+
+#~ msgid "Connected encoders: {encodersConnected}"
+#~ msgstr "Các bộ mã hóa đã kết nối: {encodersConnected}"
+
+#~ msgid "No encoders connected"
+#~ msgstr "Không có bộ mã hóa nào được kết nối"
+
+#~ msgid "Encoder settings for {name}"
+#~ msgstr "Cài đặt mã hóa cho {name}"
+
+#~ msgid "Stream &label"
+#~ msgstr "&Nhãn phát thanh"
+
+#~ msgid "&Focus to Studio when connected"
+#~ msgstr "&Chuyển về Studio khi đã kết nối"
+
+#~ msgid "&Play first track when connected"
+#~ msgstr "&Phát track đầu tiên khi kết nối"
+
+#~ msgid "Enable background connection &monitoring"
+#~ msgstr "Bật kết nối và theo dõi ngầ&m"
+
+#~ msgid "Play connection status &beep while connecting"
+#~ msgstr "Phát trạng thái kết nối &beep trong khi kết nối"
+
+#~ msgid "{encoder} {encoderNumber}: {status}"
+#~ msgstr "{encoder} {encoderNumber}: {status}"
+
+#~ msgid "Switch to Studio after connecting"
+#~ msgstr "Chuyển đến Studio sau khi kết nối"
+
+#~ msgid "Do not switch to Studio after connecting"
+#~ msgstr "Không chuyển đến Studio sau khi kết nối"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will switch to Studio when connected to a streaming "
+#~ "server."
+#~ msgstr ""
+#~ "Bật chế độ để NVDA sẽ chuyển đến Studio khi đã kết nối đến một máy chủ "
+#~ "phát thanh."
+
+#~ msgid "Play first track after connecting"
+#~ msgstr "Phát track đầu tiên sau khi kết nối"
+
+#~ msgid "Do not play first track after connecting"
+#~ msgstr "Không phát track đầu tiên sau khi kết nối"
+
+#~ msgid ""
+#~ "Toggles whether Studio will play the first song when connected to a "
+#~ "streaming server."
+#~ msgstr ""
+#~ "Bật chế độ để Studio sẽ phát bài nhạc đầu tiên khi kết nối vào máy chủ "
+#~ "đang phát."
+
+#~ msgid "Monitoring encoder {encoderNumber}"
+#~ msgstr "Đang theo dõi bộ mã hóa {encoderNumber}"
+
+#~ msgid "Encoder {encoderNumber} will not be monitored"
+#~ msgstr "Bộ mã hóa {encoderNumber} sẽ không được theo dõi"
+
+#~ msgid "Encoder monitoring canceled"
+#~ msgstr "Đã hủy bỏ theo dõi bộ mã hóa"
+
+#~ msgid ""
+#~ "Toggles whether NVDA will monitor the selected encoder in the background."
+#~ msgstr "Bật / tắt chế độ ngầm theo dõi bộ mã hóa được chọn."
+
+#~ msgid "Stream labeler for {streamEntry}"
+#~ msgstr "Đặt nhãn phát cho {streamEntry}"
+
+#~ msgid "Enter the label for this stream"
+#~ msgstr "Nhập nhãn cho đường này"
+
+#~ msgid "Opens a dialog to label the selected encoder."
+#~ msgstr "Mở hộp thoại để gán nhãn cho bộ mã hóa được chọn."
+
+#~ msgid "Stream label and settings eraser"
+#~ msgstr "Nhãn phát thanh và xóa các cài đặt"
+
+#~ msgid "Enter the position of the encoder you wish to delete or will delete"
+#~ msgstr "Nhập vị trí của bộ mã hóa bạn muốn xóa hoặc sẽ xóa"
+
+#~ msgid ""
+#~ "Opens a dialog to erase stream labels and settings from an encoder that "
+#~ "was deleted."
+#~ msgstr ""
+#~ "Mở một hộp thoại để xóa các nhãn phát và các thiết lạp từ một bộ mã hóa "
+#~ "đã bị xóa."
+
+#~ msgid "Another encoder settings dialog is open."
+#~ msgstr "Một hộp thoại cài đặt mã hóa khác đang mở."
+
+#~ msgid ""
+#~ "Shows encoder configuration dialog to configure various encoder settings "
+#~ "such as stream label."
+#~ msgstr ""
+#~ "Hiển thị hộp thoại cấu hình mã hóa để cấu hình nhiều cài đặt mã hóa như "
+#~ "nhãn phát trực tuyến."
+
+#~ msgid ""
+#~ "If pressed once, reports the current time including seconds. If pressed "
+#~ "twice, reports the current date"
+#~ msgstr ""
+#~ "Bấm một lần để thông báo thời gian hiện tại bao gồm giây. Bấm hai lần để "
+#~ "thông báo ngày hiện tại"
+
+#~ msgid "Position: {pos}"
+#~ msgstr "Vị trí: {pos}"
+
+#~ msgid "Label: {label}"
+#~ msgstr "Nhãn: {label}"
+
+#~ msgid "No stream label"
+#~ msgstr "Không có nhãn phát thanh"
+
+#~ msgid "Connecting..."
+#~ msgstr "Đang kết nối..."
+
+#~ msgid "Disconnecting..."
+#~ msgstr "Đang ngắt kết nối..."
+
+#~ msgid "Connects to a streaming server."
+#~ msgstr "Kết nối với một máy chủ đang phát."
+
+#~ msgid "Encoder Settings: {setting}"
+#~ msgstr "Cài đặt mã hóa: {setting}"
+
+#~ msgid "Transfer Rate: {transferRate}"
+#~ msgstr "Tốc độ truyền tải: {transferRate}"

--- a/buildVars.py
+++ b/buildVars.py
@@ -20,7 +20,7 @@ addon_info = {
 	"addon_description" : _("""Enhances support for StationPlaylist Studio.
 In addition, adds global commands for the studio from everywhere."""),
 	# version
-	"addon_version" : "20.01",
+	"addon_version" : "20.02",
 	# Author(s)
 	"addon_author" : u"Geoff Shang, Joseph Lee and other contributors",
 	# URL for the add-on documentation support

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ For more information about the add-on, read the [add-on guide][4]. For developer
 
 IMPORTANT NOTES:
 
-* This add-on requires NVDA 2019.3 or later and StationPlaylist suite 5.20 or later.
+* This add-on requires StationPlaylist suite 5.20 or later.
 * If using Windows 8 or later, for best experience, disable audio ducking mode.
 * Starting from 2018, [changelogs for old add-on releases][5] will be found on GitHub. This add-on readme will list changes from version 17.08 (2017 onwards).
 * Certain add-on features won't work under some conditions, including running NVDA in secure mode.
@@ -37,6 +37,7 @@ Most of these will work in Studio only unless otherwise specified.
 * Alt+NVDA+R from Studio window: Steps through library scan announcement settings.
 * Control+Shift+X from Studio window: Steps through braille timer settings.
 * Control+Alt+left/right arrow (while focused on a track in Studio, Creator, and Track Tool): Announce previous/next track column.
+* Control+Alt+Home/End (while focused on a track in Studio, Creator, and Track Tool): Announce first/last track column.
 * Control+Alt+up/down arrow (while focused on a track in Studio only): Move to previous or next track and announce specific columns.
 * Control+NVDA+1 through 0 (while focused on a track in Studio, Creator, and Track Tool): Announce column content for a specified column. Pressing this command twice will display column information on a browse mode window.
 * Control+NVDA+- (hyphen while focused on a track in Studio, Creator, and Track Tool): display data for all columns in a track on a browse mode window.

--- a/readme.md
+++ b/readme.md
@@ -200,10 +200,11 @@ If you are using Studio on a touchscreen computer running Windows 8 or later and
 ## Version 20.02
 
 * Initial support for StationPlaylist Creator's Playlist Editor.
-* Added Alt+NVDA+number row commands to announce various status information in Playlist Editor. These include date and time for the playlist (1), total playlist duration (2), when the selected track is scheduled to play (3) and rotation and category (4).
+* Added Alt+NVDA+number row commands to announce various status information in Playlist Editor. These include date and time for the playlist (1), total playlist duration (2), when the selected track is scheduled to play (3), and rotation and category (4).
 * While focused on a track in Creator and Track Tool (except in Creator's Playlist Editor), pressing Control+NVDA+Dash will display data for all columns on a browse mode window.
 * If NVDA Recognizes a track list item with less than 10 columns, NVDA will no longer announce headers for nonexistent columns if Control+NVDA+number row for out of range column is pressed.
 * In creator, NVDA will no longer announce column information if Control+NVDA+number row keys are pressed while focused on places other than track list.
+* When a track is playing, NVDA will no longer announce "no track is playing" if obtaining information about current and next tracks via SPL Assistant or SPL Controller.
 
 ## Version 20.01
 

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,13 @@ Most of these will work in Studio only unless otherwise specified.
 * Control+Alt+T (two finger flick down in SPL touch mode) from Studio window: announce remaining time for the currently playing trakc.
 * NVDA+Shift+F12 (two finger flick up in SPL touch mode) from Studio window: announces broadcaster time such as 5 minutes to top of the hour. Pressing this command twice will announce minutes and seconds till top of the hour.
 * Alt+NVDA+1 (two finger flick right in SPL mode) from Studio window: Opens end of track setting dialog.
+* Alt+NVDA+1 from Creator's Playlist Editor window: Announces scheduled time for the loaded playlist.
 * Alt+NVDA+2 (two finger flick left in SPL mode) from Studio window: Opens song intro alarm setting dialog.
+* Alt+NVDA+2 from Creator's Playlist Editor window: Announces total playlist duration.
 * Alt+NVDA+3 from Studio window: Toggles cart explorer to learn cart assignments.
+* Alt+NVDA+3 from Creator's Playlist Editor window: Announces when the selected track is scheduled to play.
 * Alt+NVDA+4 from Studio window: Opens microphone alarm dialog.
+* Alt+NVDA+4 from Creator's Playlist Editor window: Announces rotation and category associated with the loaded playlist.
 * Control+NVDA+f from Studio window: Opens a dialog to find a track based on artist or song name. Press NVDA+F3 to find forward or NVDA+Shift+F3 to find backward.
 * Alt+NVDA+R from Studio window: Steps through library scan announcement settings.
 * Control+Shift+X from Studio window: Steps through braille timer settings.
@@ -194,7 +198,9 @@ If you are using Studio on a touchscreen computer running Windows 8 or later and
 
 ## Version 20.02
 
-* While focused on a track in Creator and Track Tool, pressing Control+NVDA+Dash will display data for all columns on a browse mode window.
+* Initial support for StationPlaylist Creator's Playlist Editor.
+* Added Alt+NVDA+number row commands to announce various status information in Playlist Editor. These include date and time for the playlist (1), total playlist duration (2), when the selected track is scheduled to play (3) and rotation and category (4).
+* While focused on a track in Creator and Track Tool (except in Creator's Playlist Editor), pressing Control+NVDA+Dash will display data for all columns on a browse mode window.
 * If NVDA Recognizes a track list item with less than 10 columns, NVDA will no longer announce headers for nonexistent columns if Control+NVDA+number row for out of range column is pressed.
 * In creator, NVDA will no longer announce column information if Control+NVDA+number row keys are pressed while focused on places other than track list.
 

--- a/readme.md
+++ b/readme.md
@@ -205,6 +205,8 @@ If you are using Studio on a touchscreen computer running Windows 8 or later and
 * If NVDA Recognizes a track list item with less than 10 columns, NVDA will no longer announce headers for nonexistent columns if Control+NVDA+number row for out of range column is pressed.
 * In creator, NVDA will no longer announce column information if Control+NVDA+number row keys are pressed while focused on places other than track list.
 * When a track is playing, NVDA will no longer announce "no track is playing" if obtaining information about current and next tracks via SPL Assistant or SPL Controller.
+* If an alarm options dialog (intro, outro, microphone) is open, NVDA will no longer appear to do nothing or play error tone if attempting to open a second instance of any alarm dialog.
+* When trying to switch between active profile and an instant profile via SPL Assistant (F12), NVDA will present a message if attempting to do so while add-on settings screen is open.
 
 ## Version 20.01
 

--- a/readme.md
+++ b/readme.md
@@ -207,6 +207,7 @@ If you are using Studio on a touchscreen computer running Windows 8 or later and
 * When a track is playing, NVDA will no longer announce "no track is playing" if obtaining information about current and next tracks via SPL Assistant or SPL Controller.
 * If an alarm options dialog (intro, outro, microphone) is open, NVDA will no longer appear to do nothing or play error tone if attempting to open a second instance of any alarm dialog.
 * When trying to switch between active profile and an instant profile via SPL Assistant (F12), NVDA will present a message if attempting to do so while add-on settings screen is open.
+* In encoders, NVDA will no longer forget to apply no connection tone setting for encoders when NVDA is restarted.
 
 ## Version 20.01
 


### PR DESCRIPTION
StationPlaylist add-on 20.02. This pull request should be used for all 20.02.x releases.

NVDA compatibility: 2019.3 and later

Changelog:

* Initial support for StationPlaylist Creator's Playlist Editor.
* Added Alt+NVDA+number row commands to announce various status information in Playlist Editor. These include date and time for the playlist (1), total playlist duration (2), when the selected track is scheduled to play (3), and rotation and category (4).
* While focused on a track in Creator and Track Tool (except in Creator's Playlist Editor), pressing Control+NVDA+Dash will display data for all columns on a browse mode window.
* If NVDA Recognizes a track list item with less than 10 columns, NVDA will no longer announce headers for nonexistent columns if Control+NVDA+number row for out of range column is pressed.
* In creator, NVDA will no longer announce column information if Control+NVDA+number row keys are pressed while focused on places other than track list.
* When a track is playing, NVDA will no longer announce "no track is playing" if obtaining information about current and next tracks via SPL Assistant or SPL Controller.
* If an alarm options dialog (intro, outro, microphone) is open, NVDA will no longer appear to do nothing or play error tone if attempting to open a second instance of any alarm dialog.
* When trying to switch between active profile and an instant profile via SPL Assistant (F12), NVDA will present a message if attempting to do so while add-on settings screen is open.

Along with copyright header updates and code adjustments.